### PR TITLE
Consensus: More verbose logging for header validation

### DIFF
--- a/src/main/java/org/semux/consensus/SemuxBft.java
+++ b/src/main/java/org/semux/consensus/SemuxBft.java
@@ -852,9 +852,13 @@ public class SemuxBft implements Consensus {
         // [2] check transactions and results (skipped)
         List<Transaction> unvalidatedTransactions = getUnvalidatedTransactions(transactions);
 
-        if (!Block.validateTransactions(header, unvalidatedTransactions, transactions, config.network())
-                || transactions.stream().mapToInt(Transaction::size).sum() > config.maxBlockTransactionsSize()) {
+        if (!Block.validateTransactions(header, unvalidatedTransactions, transactions, config.network())) {
             logger.warn("Invalid block transactions");
+            return false;
+        }
+
+        if (transactions.stream().mapToInt(Transaction::size).sum() > config.maxBlockTransactionsSize()) {
+            logger.warn("Block transactions size exceeds maximum");
             return false;
         }
 

--- a/src/main/java/org/semux/core/Block.java
+++ b/src/main/java/org/semux/core/Block.java
@@ -130,6 +130,7 @@ public class Block {
             logger.warn("Header was null.");
             return false;
         }
+
         if (!header.validate()) {
             logger.warn("Header was invalid.");
             return false;

--- a/src/main/java/org/semux/core/Block.java
+++ b/src/main/java/org/semux/core/Block.java
@@ -18,11 +18,14 @@ import org.semux.crypto.Key.Signature;
 import org.semux.util.MerkleUtil;
 import org.semux.util.SimpleDecoder;
 import org.semux.util.SimpleEncoder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Represents a block in the blockchain.
  */
 public class Block {
+    static final Logger logger = LoggerFactory.getLogger(Block.class);
 
     /**
      * The block header.
@@ -123,10 +126,31 @@ public class Block {
      * @return
      */
     public static boolean validateHeader(BlockHeader previous, BlockHeader header) {
-        return header != null && header.validate()
-                && header.getNumber() == previous.getNumber() + 1
-                && Arrays.equals(header.getParentHash(), previous.getHash())
-                && header.getTimestamp() > previous.getTimestamp();
+        if (header == null) {
+            logger.warn("Header was null.");
+            return false;
+        }
+        if (!header.validate()) {
+            logger.warn("Header was invalid.");
+            return false;
+        }
+
+        if (header.getNumber() != previous.getNumber() + 1) {
+            logger.warn("Header number was not one greater than previous block.");
+            return false;
+        }
+
+        if (!Arrays.equals(header.getParentHash(), previous.getHash())) {
+            logger.warn("Header parent hash was not equal to previous block hash.");
+            return false;
+        }
+
+        if (header.getTimestamp() <= previous.getTimestamp()) {
+            logger.warn("Header timestamp was before previous block.");
+            return false;
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
Log the reason for a block header being invalid.  As we recently found
the time issue for headers, it seems like we need clearer language for
logging failed vote reasons.