### PR TITLE
Core: Use NTP time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <issueManagement>
         <system>GitHub</system>
-        <url>https://github.com/semuxproject/semux-core/issues</url>
+        <url>https://github.com/semuxproject/semux/issues</url>
     </issueManagement>
 
     <repositories>
@@ -638,6 +638,7 @@
                                         <urn>commons-digester:commons-digester:1.8.1:jar:null:compile:3dec9b9c7ea9342d4dbe8c38560080d85b44a015</urn>
                                         <urn>commons-io:commons-io:2.6:jar:null:test:815893df5f31da2ece4040fe0a12fd44b577afaf</urn>
                                         <urn>commons-logging:commons-logging:1.2:jar:null:compile:4bfc12adfe4842bf07b657f0369c4cb522955686</urn>
+                                        <urn>commons-net:commons-net:3.3:jar:null:compile:cd0d5510908225f76c5fe5a3f1df4fa44866f81e</urn>
                                         <urn>commons-validator:commons-validator:1.6:jar:null:compile:e989d1e87cdd60575df0765ed5bac65c905d7908</urn>
                                         <urn>de.erichseifert.vectorgraphics2d:VectorGraphics2D:0.11:jar:null:test:f3bf8fe05b7997e03941bf77428598137500c300</urn>
                                         <urn>io.netty:netty-all:4.1.22.Final:jar:null:compile:c1cea5d30025e4d584d2b287d177c31aea4ae629</urn>
@@ -954,6 +955,11 @@
             <artifactId>commons-io</artifactId>
             <version>2.6</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-net</groupId>
+            <artifactId>commons-net</artifactId>
+            <version>3.3</version>
         </dependency>
 
         <!-- JSON -->

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <issueManagement>
         <system>GitHub</system>
-        <url>https://github.com/semuxproject/semux/issues</url>
+        <url>https://github.com/semuxproject/semux-core/issues</url>
     </issueManagement>
 
     <repositories>

--- a/src/main/java/org/semux/api/http/HttpHandler.java
+++ b/src/main/java/org/semux/api/http/HttpHandler.java
@@ -256,7 +256,7 @@ public class HttpHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
 
     private ChannelFuture writeApiResponse(ChannelHandlerContext ctx, Boolean prettyPrint, Object response) {
         HttpResponseStatus status;
-        if (response instanceof javax.ws.rs.core.Response) { // since v2.0.0, a standard JAX-RS response is provided
+        if (response instanceof Response) { // since v2.0.0, a standard JAX-RS response is provided
             status = HttpResponseStatus.valueOf(((Response) response).getStatus());
             response = ((Response) response).getEntity();
         } else { // prior to v2.0.0, status is always OK

--- a/src/main/java/org/semux/api/util/TransactionBuilder.java
+++ b/src/main/java/org/semux/api/util/TransactionBuilder.java
@@ -17,6 +17,7 @@ import org.semux.crypto.CryptoException;
 import org.semux.crypto.Hex;
 import org.semux.crypto.Key;
 import org.semux.util.Bytes;
+import org.semux.util.TimeUtil;
 
 /**
  * This is a builder class for building transactions required by Semux API with
@@ -224,7 +225,7 @@ public class TransactionBuilder {
                 value,
                 fee,
                 nonce != null ? nonce : kernel.getPendingManager().getNonce(account.toAddress()),
-                timestamp != null ? timestamp : System.currentTimeMillis(),
+                timestamp != null ? timestamp : TimeUtil.currentTimeMillis(),
                 data);
     }
 

--- a/src/main/java/org/semux/api/v1_0_1/SemuxApi.java
+++ b/src/main/java/org/semux/api/v1_0_1/SemuxApi.java
@@ -218,7 +218,8 @@ public interface SemuxApi {
     @Path("vote")
     @ApiOperation(value = "Vote", notes = "Votes for a delegate.", response = DoTransactionResponse.class)
     @Produces(JSON_MIME)
-    ApiHandlerResponse vote(@ApiParam(value = "Voting address", required = true) @QueryParam("from") String from,
+    ApiHandlerResponse vote(
+            @ApiParam(value = "Voting address", required = true) @QueryParam("from") String from,
             @ApiParam(value = "Delegate address", required = true) @QueryParam("to") String to,
             @ApiParam(value = "Vote amount", required = true) @QueryParam("value") String value,
             @ApiParam(value = "Transaction fee", required = true) @QueryParam("fee") String fee);
@@ -227,7 +228,8 @@ public interface SemuxApi {
     @Path("unvote")
     @ApiOperation(value = "Unvote", notes = "Unvotes for a delegate.", response = DoTransactionResponse.class)
     @Produces(JSON_MIME)
-    ApiHandlerResponse unvote(@ApiParam(value = "Voting address", required = true) @QueryParam("from") String from,
+    ApiHandlerResponse unvote(
+            @ApiParam(value = "Voting address", required = true) @QueryParam("from") String from,
             @ApiParam(value = "Delegate address", required = true) @QueryParam("to") String to,
             @ApiParam(value = "Vote amount", required = true) @QueryParam("value") String value,
             @ApiParam(value = "Transaction fee", required = true) @QueryParam("fee") String fee);

--- a/src/main/java/org/semux/api/v1_0_1/response/Types.java
+++ b/src/main/java/org/semux/api/v1_0_1/response/Types.java
@@ -96,7 +96,7 @@ public class Types {
         public final String data;
 
         @JsonProperty("transactions")
-        public final List<Types.TransactionType> transactions;
+        public final List<TransactionType> transactions;
 
         public BlockType(
                 @JsonProperty("hash") String hash,
@@ -110,7 +110,7 @@ public class Types {
                 @JsonProperty("resultsRoot") String resultsRoot,
                 @JsonProperty("stateRoot") String stateRoot,
                 @JsonProperty("data") String data,
-                @JsonProperty("transactions") List<Types.TransactionType> transactions) {
+                @JsonProperty("transactions") List<TransactionType> transactions) {
             this.hash = hash;
             this.number = number;
             this.view = view;
@@ -138,7 +138,7 @@ public class Types {
                     Hex.encode0x(block.getStateRoot()),
                     Hex.encode0x(block.getData()),
                     block.getTransactions().stream()
-                            .map(tx -> new Types.TransactionType(block.getNumber(), tx))
+                            .map(tx -> new TransactionType(block.getNumber(), tx))
                             .collect(Collectors.toList()));
         }
     }

--- a/src/main/java/org/semux/cli/SemuxCli.java
+++ b/src/main/java/org/semux/cli/SemuxCli.java
@@ -30,6 +30,7 @@ import org.semux.net.filter.exception.IpFilterJsonParseException;
 import org.semux.util.ConsoleUtil;
 import org.semux.util.FileUtil;
 import org.semux.util.SystemUtil;
+import org.semux.util.TimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -178,6 +179,11 @@ public class SemuxCli extends Launcher {
             if (!FileUtil.isPosixPermissionSecured(getConfig().getFile())) {
                 logger.warn(CliMessages.get("WarningConfigPosixPermission"));
             }
+        }
+
+        long timeDrift = TimeUtil.getTimeOffsetFromNtp();
+        if (Math.abs(timeDrift) > 20000L) {
+            logger.warn(CliMessages.get("SystemTimeDrift"));
         }
 
         // create a new account if the wallet is empty

--- a/src/main/java/org/semux/consensus/SemuxBft.java
+++ b/src/main/java/org/semux/consensus/SemuxBft.java
@@ -59,6 +59,7 @@ import org.semux.util.ByteArray;
 import org.semux.util.Bytes;
 import org.semux.util.MerkleUtil;
 import org.semux.util.SystemUtil;
+import org.semux.util.TimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -189,7 +190,7 @@ public class SemuxBft implements Consensus {
                 }
 
                 // in case we get stuck at one height for too long
-                if (lastUpdate + 2 * 60 * 1000L < System.currentTimeMillis()) {
+                if (lastUpdate + 2 * 60 * 1000L < TimeUtil.currentTimeMillis()) {
                     updateValidators();
                 }
 
@@ -251,7 +252,7 @@ public class SemuxBft implements Consensus {
             broadcaster.stop();
 
             status = Status.STOPPED;
-            Event ev = new Event(Event.Type.STOP);
+            Event ev = new Event(Type.STOP);
             if (!events.offer(ev)) {
                 logger.error("Failed to add an event to message queue: ev = {}", ev);
             }
@@ -616,7 +617,7 @@ public class SemuxBft implements Consensus {
             channel.getRemotePeer().setLatestBlockNumber(m.getHeight() - 1);
 
             if (m.getHeight() > height) {
-                events.add(new Event(Event.Type.NEW_HEIGHT, m.getHeight()));
+                events.add(new Event(Type.NEW_HEIGHT, m.getHeight()));
             }
             break;
         }
@@ -627,9 +628,9 @@ public class SemuxBft implements Consensus {
             channel.getRemotePeer().setLatestBlockNumber(m.getHeight() - 1);
 
             if (m.getHeight() > height) {
-                events.add(new Event(Event.Type.NEW_HEIGHT, m.getHeight()));
+                events.add(new Event(Type.NEW_HEIGHT, m.getHeight()));
             } else if (m.getHeight() == height) {
-                events.add(new Event(Event.Type.NEW_VIEW, m.getProof()));
+                events.add(new Event(Type.NEW_VIEW, m.getProof()));
             }
             break;
         }
@@ -639,7 +640,7 @@ public class SemuxBft implements Consensus {
 
             if (p.getHeight() == height) {
                 if (p.validate()) {
-                    events.add(new Event(Event.Type.PROPOSAL, m.getProposal()));
+                    events.add(new Event(Type.PROPOSAL, m.getProposal()));
                 } else {
                     logger.debug("Invalid proposal from {}", channel.getRemotePeer().getPeerId());
                     channel.getMessageQueue().disconnect(ReasonCode.BAD_PEER);
@@ -653,7 +654,7 @@ public class SemuxBft implements Consensus {
 
             if (vote.getHeight() == height) {
                 if (vote.revalidate()) {
-                    events.add(new Event(Event.Type.VOTE, vote));
+                    events.add(new Event(Type.VOTE, vote));
                 } else {
                     logger.debug("Invalid vote from {}", channel.getRemotePeer().getPeerId());
                     channel.getMessageQueue().disconnect(ReasonCode.BAD_PEER);
@@ -687,7 +688,7 @@ public class SemuxBft implements Consensus {
     protected void updateValidators() {
         validators = chain.getValidators();
         activeValidators = channelMgr.getActiveChannels(validators);
-        lastUpdate = System.currentTimeMillis();
+        lastUpdate = TimeUtil.currentTimeMillis();
     }
 
     /**
@@ -759,7 +760,7 @@ public class SemuxBft implements Consensus {
      * @return the proposed block
      */
     protected Block proposeBlock() {
-        long t1 = System.currentTimeMillis();
+        long t1 = TimeUtil.currentTimeMillis();
 
         // fetch pending transactions
         final List<PendingManager.PendingTransaction> pending = pendingMgr
@@ -779,7 +780,7 @@ public class SemuxBft implements Consensus {
         // construct block
         long number = height;
         byte[] prevHash = chain.getBlockHeader(height - 1).getHash();
-        long timestamp = System.currentTimeMillis();
+        long timestamp = TimeUtil.currentTimeMillis();
 
         // signal UNIFORM_DISTRIBUTION fork
         byte[] data = signalingUniformDistribution()
@@ -790,7 +791,7 @@ public class SemuxBft implements Consensus {
                 resultsRoot, stateRoot, data);
         Block block = new Block(header, pendingTxs, pendingResults);
 
-        long t2 = System.currentTimeMillis();
+        long t2 = TimeUtil.currentTimeMillis();
         logger.debug("Block creation: # txs = {}, time = {} ms", pendingTxs.size(), t2 - t1);
 
         return block;
@@ -825,7 +826,7 @@ public class SemuxBft implements Consensus {
      * @return
      */
     protected boolean validateBlock(BlockHeader header, List<Transaction> transactions) {
-        long t1 = System.currentTimeMillis();
+        long t1 = TimeUtil.currentTimeMillis();
 
         // [1] check block header
         Block latest = chain.getLatestBlock();
@@ -834,7 +835,7 @@ public class SemuxBft implements Consensus {
             return false;
         }
 
-        if (header.getTimestamp() - System.currentTimeMillis() > config.maxBlockTimeDrift()) {
+        if (header.getTimestamp() - TimeUtil.currentTimeMillis() > config.maxBlockTimeDrift()) {
             logger.warn("A block in the future is not allowed");
             return false;
         }
@@ -874,7 +875,7 @@ public class SemuxBft implements Consensus {
             return false;
         }
 
-        long t2 = System.currentTimeMillis();
+        long t2 = TimeUtil.currentTimeMillis();
         logger.debug("Block validation: # txs = {}, time = {} ms", transactions.size(), t2 - t1);
 
         Block block = new Block(header, transactions, results);
@@ -985,7 +986,7 @@ public class SemuxBft implements Consensus {
         public void run() {
             while (!Thread.currentThread().isInterrupted()) {
                 synchronized (this) {
-                    if (timeout != -1 && timeout < System.currentTimeMillis()) {
+                    if (timeout != -1 && timeout < TimeUtil.currentTimeMillis()) {
                         events.add(new Event(Type.TIMEOUT));
                         timeout = -1;
                         continue;
@@ -1025,7 +1026,7 @@ public class SemuxBft implements Consensus {
             if (milliseconds < 0) {
                 throw new IllegalArgumentException("Timeout can not be negative");
             }
-            timeout = System.currentTimeMillis() + milliseconds;
+            timeout = TimeUtil.currentTimeMillis() + milliseconds;
         }
 
         public synchronized void clear() {

--- a/src/main/java/org/semux/consensus/SemuxSync.java
+++ b/src/main/java/org/semux/consensus/SemuxSync.java
@@ -224,7 +224,7 @@ public class SemuxSync implements SyncManager {
 
         synchronized (lock) {
             // filter all expired tasks
-            long now = System.currentTimeMillis();
+            long now = TimeUtil.currentTimeMillis();
             Iterator<Entry<Long, Long>> itr = toComplete.entrySet().iterator();
             while (itr.hasNext()) {
                 Entry<Long, Long> entry = itr.next();
@@ -276,7 +276,7 @@ public class SemuxSync implements SyncManager {
                 if (toDownload.remove(task)) {
                     growToDownloadQueue();
                 }
-                toComplete.put(task, System.currentTimeMillis());
+                toComplete.put(task, TimeUtil.currentTimeMillis());
             }
         }
     }
@@ -490,7 +490,7 @@ public class SemuxSync implements SyncManager {
                 Duration.between(beginningInstant != null ? beginningInstant : Instant.now(), Instant.now()));
     }
 
-    public static class SemuxSyncProgress implements SyncManager.Progress {
+    public static class SemuxSyncProgress implements Progress {
 
         final long startingHeight;
 

--- a/src/main/java/org/semux/consensus/ValidatorActivatedFork.java
+++ b/src/main/java/org/semux/consensus/ValidatorActivatedFork.java
@@ -19,7 +19,7 @@ public final class ValidatorActivatedFork implements Comparable<ValidatorActivat
 
     /**
      * This soft fork introduces an uniformly-distributed hash function for choosing
-     * primary validator. See: https://github.com/semuxproject/semux/issues/620
+     * primary validator.
      */
     public static final ValidatorActivatedFork UNIFORM_DISTRIBUTION = new ValidatorActivatedFork((short) 1,
             "UNIFORM_DISTRIBUTION", 1500, 2000, 1000000);

--- a/src/main/java/org/semux/consensus/ValidatorActivatedFork.java
+++ b/src/main/java/org/semux/consensus/ValidatorActivatedFork.java
@@ -19,7 +19,7 @@ public final class ValidatorActivatedFork implements Comparable<ValidatorActivat
 
     /**
      * This soft fork introduces an uniformly-distributed hash function for choosing
-     * primary validator.
+     * primary validator. See: https://github.com/semuxproject/semux/issues/620
      */
     public static final ValidatorActivatedFork UNIFORM_DISTRIBUTION = new ValidatorActivatedFork((short) 1,
             "UNIFORM_DISTRIBUTION", 1500, 2000, 1000000);

--- a/src/main/java/org/semux/core/BlockchainImpl.java
+++ b/src/main/java/org/semux/core/BlockchainImpl.java
@@ -42,6 +42,7 @@ import org.semux.event.PubSubFactory;
 import org.semux.util.Bytes;
 import org.semux.util.SimpleDecoder;
 import org.semux.util.SimpleEncoder;
+import org.semux.util.TimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -601,7 +602,7 @@ public class BlockchainImpl implements Blockchain {
     private void setActivatedForks(Map<ValidatorActivatedFork, ValidatorActivatedFork.Activation> activatedForks) {
         SimpleEncoder simpleEncoder = new SimpleEncoder();
         simpleEncoder.writeInt(activatedForks.size());
-        for (Map.Entry<ValidatorActivatedFork, ValidatorActivatedFork.Activation> entry : activatedForks.entrySet()) {
+        for (Entry<ValidatorActivatedFork, ValidatorActivatedFork.Activation> entry : activatedForks.entrySet()) {
             simpleEncoder.writeBytes(entry.getValue().toBytes());
         }
         indexDB.put(getActivatedForksKey(), simpleEncoder.toBytes());
@@ -849,7 +850,7 @@ public class BlockchainImpl implements Blockchain {
                 String dbName = dbFactory.getDataDir().getFileName().toString();
                 Path tempPath = dbFactory
                         .getDataDir()
-                        .resolveSibling(dbName + "_tmp_" + System.currentTimeMillis());
+                        .resolveSibling(dbName + "_tmp_" + TimeUtil.currentTimeMillis());
                 LeveldbDatabase.LeveldbFactory tempDb = new LeveldbDatabase.LeveldbFactory(tempPath.toFile());
                 MigrationBlockchain migrationBlockchain = new MigrationBlockchain(config, tempDb);
                 final long latestBlockNumber = getLatestBlockNumber();
@@ -868,7 +869,8 @@ public class BlockchainImpl implements Blockchain {
                 Path backupPath = dbFactory
                         .getDataDir()
                         .resolveSibling(
-                                dbFactory.getDataDir().getFileName().toString() + "_bak_" + System.currentTimeMillis());
+                                dbFactory.getDataDir().getFileName().toString() + "_bak_"
+                                        + TimeUtil.currentTimeMillis());
                 dbFactory.moveTo(backupPath);
                 tempDb.moveTo(dbFactory.getDataDir());
                 dbFactory.open();

--- a/src/main/java/org/semux/core/PendingManager.java
+++ b/src/main/java/org/semux/core/PendingManager.java
@@ -25,6 +25,7 @@ import org.semux.net.msg.p2p.TransactionMessage;
 import org.semux.util.ArrayUtil;
 import org.semux.util.ByteArray;
 import org.semux.util.Bytes;
+import org.semux.util.TimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -242,7 +243,7 @@ public class PendingManager implements Runnable, BlockchainListener {
     @Override
     public synchronized void onBlockAdded(Block block) {
         if (isRunning) {
-            long t1 = System.currentTimeMillis();
+            long t1 = TimeUtil.currentTimeMillis();
 
             // clear transaction pool
             List<PendingTransaction> txs = reset();
@@ -253,7 +254,7 @@ public class PendingManager implements Runnable, BlockchainListener {
                 accepted += processTransaction(tx.transaction, false).accepted;
             }
 
-            long t2 = System.currentTimeMillis();
+            long t2 = TimeUtil.currentTimeMillis();
             logger.debug("Pending tx evaluation: # txs = {} / {},  time = {} ms", accepted, txs.size(), t2 - t1);
         }
     }
@@ -294,7 +295,7 @@ public class PendingManager implements Runnable, BlockchainListener {
     protected ProcessTransactionResult processTransaction(Transaction tx, boolean relay) {
 
         int cnt = 0;
-        long now = System.currentTimeMillis();
+        long now = TimeUtil.currentTimeMillis();
 
         // reject transactions with a duplicated tx hash
         if (kernel.getBlockchain().hasTransaction(tx.getHash())) {

--- a/src/main/java/org/semux/core/state/AccountStateImpl.java
+++ b/src/main/java/org/semux/core/state/AccountStateImpl.java
@@ -137,7 +137,7 @@ public class AccountStateImpl implements AccountState {
     public void commit() {
         synchronized (updates) {
             if (prev == null) {
-                for (Map.Entry<ByteArray, byte[]> entry : updates.entrySet()) {
+                for (Entry<ByteArray, byte[]> entry : updates.entrySet()) {
                     if (entry.getValue() == null) {
                         accountDB.delete(entry.getKey().getData());
                     } else {

--- a/src/main/java/org/semux/core/state/DelegateStateImpl.java
+++ b/src/main/java/org/semux/core/state/DelegateStateImpl.java
@@ -205,7 +205,7 @@ public class DelegateStateImpl implements DelegateState {
     public void commit() {
         synchronized (delegateUpdates) {
             if (prev == null) {
-                for (Map.Entry<ByteArray, byte[]> entry : delegateUpdates.entrySet()) {
+                for (Entry<ByteArray, byte[]> entry : delegateUpdates.entrySet()) {
                     if (entry.getValue() == null) {
                         delegateDB.delete(entry.getKey().getData());
                     } else {
@@ -223,7 +223,7 @@ public class DelegateStateImpl implements DelegateState {
 
         synchronized (voteUpdates) {
             if (prev == null) {
-                for (Map.Entry<ByteArray, byte[]> entry : voteUpdates.entrySet()) {
+                for (Entry<ByteArray, byte[]> entry : voteUpdates.entrySet()) {
                     if (entry.getValue() == null) {
                         voteDB.delete(entry.getKey().getData());
                     } else {
@@ -252,7 +252,7 @@ public class DelegateStateImpl implements DelegateState {
      * @param map
      */
     protected void getDelegates(Map<ByteArray, Delegate> map) {
-        for (Map.Entry<ByteArray, byte[]> entry : delegateUpdates.entrySet()) {
+        for (Entry<ByteArray, byte[]> entry : delegateUpdates.entrySet()) {
             /* filter address */
             if (entry.getKey().length() == ADDRESS_LEN && !map.containsKey(entry.getKey())) {
                 if (entry.getValue() == null) {

--- a/src/main/java/org/semux/gui/MenuBar.java
+++ b/src/main/java/org/semux/gui/MenuBar.java
@@ -43,7 +43,7 @@ public class MenuBar extends JMenuBar implements ActionListener {
 
     private static final long serialVersionUID = 1L;
     private static final Logger logger = LoggerFactory.getLogger(MenuBar.class);
-    public static final String HELP_URL = "https://github.com/semuxproject/semux-core/tree/v" + Constants.CLIENT_VERSION
+    public static final String HELP_URL = "https://github.com/semuxproject/semux/tree/v" + Constants.CLIENT_VERSION
             + "/docs";
 
     private final transient SemuxGui gui;

--- a/src/main/java/org/semux/gui/MenuBar.java
+++ b/src/main/java/org/semux/gui/MenuBar.java
@@ -43,7 +43,7 @@ public class MenuBar extends JMenuBar implements ActionListener {
 
     private static final long serialVersionUID = 1L;
     private static final Logger logger = LoggerFactory.getLogger(MenuBar.class);
-    public static final String HELP_URL = "https://github.com/semuxproject/semux/tree/v" + Constants.CLIENT_VERSION
+    public static final String HELP_URL = "https://github.com/semuxproject/semux-core/tree/v" + Constants.CLIENT_VERSION
             + "/docs";
 
     private final transient SemuxGui gui;

--- a/src/main/java/org/semux/gui/dialog/AddressBookDialog.java
+++ b/src/main/java/org/semux/gui/dialog/AddressBookDialog.java
@@ -8,7 +8,6 @@ package org.semux.gui.dialog;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.Dialog;
 import java.awt.Dimension;
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
@@ -52,7 +51,7 @@ public class AddressBookDialog extends JDialog implements ActionListener {
     private final AddressTableModel tableModel;
 
     public AddressBookDialog(JFrame parent, Wallet wallet, SemuxGui gui) {
-        super(null, GuiMessages.get("AddressBook"), Dialog.ModalityType.MODELESS);
+        super(null, GuiMessages.get("AddressBook"), ModalityType.MODELESS);
         this.setName("AddressBookDialog");
 
         this.wallet = wallet;

--- a/src/main/java/org/semux/gui/dialog/ConsoleDialog.java
+++ b/src/main/java/org/semux/gui/dialog/ConsoleDialog.java
@@ -7,7 +7,6 @@
 package org.semux.gui.dialog;
 
 import java.awt.BorderLayout;
-import java.awt.Dialog;
 import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -52,7 +51,7 @@ public class ConsoleDialog extends JDialog implements ActionListener {
 
     public ConsoleDialog(SemuxGui gui, JFrame parent) {
 
-        super(null, GuiMessages.get("Console"), Dialog.ModalityType.MODELESS);
+        super(null, GuiMessages.get("Console"), ModalityType.MODELESS);
 
         setName("Console");
 

--- a/src/main/java/org/semux/gui/dialog/DelegateDialog.java
+++ b/src/main/java/org/semux/gui/dialog/DelegateDialog.java
@@ -6,8 +6,6 @@
  */
 package org.semux.gui.dialog;
 
-import java.awt.Dialog;
-
 import javax.swing.GroupLayout;
 import javax.swing.GroupLayout.Alignment;
 import javax.swing.JDialog;
@@ -28,7 +26,7 @@ public class DelegateDialog extends JDialog {
     private static final long serialVersionUID = 1L;
 
     public DelegateDialog(SemuxGui gui, JFrame parent, WalletDelegate d) {
-        super(null, GuiMessages.get("Delegate"), Dialog.ModalityType.MODELESS);
+        super(null, GuiMessages.get("Delegate"), ModalityType.MODELESS);
         setName("DelegateDialog");
         Block block = gui.getKernel().getBlockchain().getBlock(d.getRegisteredAt());
 

--- a/src/main/java/org/semux/gui/dialog/ExportPrivateKeyDialog.java
+++ b/src/main/java/org/semux/gui/dialog/ExportPrivateKeyDialog.java
@@ -8,7 +8,6 @@ package org.semux.gui.dialog;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.Dialog;
 import java.awt.Dimension;
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
@@ -41,7 +40,7 @@ public class ExportPrivateKeyDialog extends JDialog implements ActionListener {
     private final JTable table;
 
     public ExportPrivateKeyDialog(SemuxGui gui, JFrame parent) {
-        super(null, GuiMessages.get("ExportPrivateKey"), Dialog.ModalityType.MODELESS);
+        super(null, GuiMessages.get("ExportPrivateKey"), ModalityType.MODELESS);
         Wallet wallet = gui.getKernel().getWallet();
 
         Object[][] data = new Object[wallet.size()][];

--- a/src/main/java/org/semux/gui/dialog/InputDialog.java
+++ b/src/main/java/org/semux/gui/dialog/InputDialog.java
@@ -32,7 +32,7 @@ public class InputDialog extends JDialog implements ActionListener {
     private String text;
 
     public InputDialog(JFrame parent, String message, boolean isPassword) {
-        super(parent, GuiMessages.get("Input"), java.awt.Dialog.ModalityType.TOOLKIT_MODAL);
+        super(parent, GuiMessages.get("Input"), ModalityType.TOOLKIT_MODAL);
 
         JLabel labelLogo = new JLabel("");
         labelLogo.setIcon(SwingUtil.loadImage("logo", 96, 96));

--- a/src/main/java/org/semux/gui/dialog/SelectDialog.java
+++ b/src/main/java/org/semux/gui/dialog/SelectDialog.java
@@ -35,7 +35,7 @@ public class SelectDialog extends JDialog implements ActionListener {
     private int selected = -1;
 
     public SelectDialog(JFrame parent, String message, List<?> options) {
-        super(parent, GuiMessages.get("Select"), java.awt.Dialog.ModalityType.TOOLKIT_MODAL);
+        super(parent, GuiMessages.get("Select"), ModalityType.TOOLKIT_MODAL);
 
         JLabel labelLogo = new JLabel("");
         labelLogo.setIcon(SwingUtil.loadImage("logo", 96, 96));

--- a/src/main/java/org/semux/gui/dialog/TransactionDialog.java
+++ b/src/main/java/org/semux/gui/dialog/TransactionDialog.java
@@ -28,7 +28,7 @@ public class TransactionDialog extends JDialog {
     private static final long serialVersionUID = 1L;
 
     public TransactionDialog(JFrame parent, Transaction tx) {
-        super(null, GuiMessages.get("Transaction"), Dialog.ModalityType.MODELESS);
+        super(null, GuiMessages.get("Transaction"), ModalityType.MODELESS);
         setName("TransactionDialog");
 
         JLabel lblHash = new JLabel(GuiMessages.get("Hash") + ":");

--- a/src/main/java/org/semux/gui/panel/DelegatesPanel.java
+++ b/src/main/java/org/semux/gui/panel/DelegatesPanel.java
@@ -61,6 +61,7 @@ import org.semux.gui.model.WalletModel;
 import org.semux.message.GuiMessages;
 import org.semux.util.Bytes;
 import org.semux.util.SystemUtil;
+import org.semux.util.TimeUtil;
 import org.semux.util.exception.UnreachableException;
 
 public class DelegatesPanel extends JPanel implements ActionListener {
@@ -532,7 +533,7 @@ public class DelegatesPanel extends JPanel implements ActionListener {
             byte[] fromAddress = a.getKey().toAddress();
             byte[] toAddress = d.getAddress();
             long nonce = pendingMgr.getNonce(fromAddress);
-            long timestamp = System.currentTimeMillis();
+            long timestamp = TimeUtil.currentTimeMillis();
             byte[] data = {};
             Transaction tx = new Transaction(network, type, toAddress, value, fee, nonce, timestamp, data);
             tx.sign(a.getKey());
@@ -600,7 +601,7 @@ public class DelegatesPanel extends JPanel implements ActionListener {
             Amount value = config.minDelegateBurnAmount();
             Amount fee = config.minTransactionFee();
             long nonce = pendingMgr.getNonce(a.getAddress());
-            long timestamp = System.currentTimeMillis();
+            long timestamp = TimeUtil.currentTimeMillis();
             byte[] data = Bytes.of(name);
             Transaction tx = new Transaction(network, type, to, value, fee, nonce, timestamp, data).sign(a.getKey());
 

--- a/src/main/java/org/semux/gui/panel/SendPanel.java
+++ b/src/main/java/org/semux/gui/panel/SendPanel.java
@@ -53,6 +53,7 @@ import org.semux.gui.model.WalletModel;
 import org.semux.message.GuiMessages;
 import org.semux.util.ByteArray;
 import org.semux.util.Bytes;
+import org.semux.util.TimeUtil;
 import org.semux.util.exception.UnreachableException;
 
 public class SendPanel extends JPanel implements ActionListener {
@@ -397,7 +398,7 @@ public class SendPanel extends JPanel implements ActionListener {
                     TransactionType type = TransactionType.TRANSFER;
                     byte[] from = acc.getKey().toAddress();
                     long nonce = pendingMgr.getNonce(from);
-                    long timestamp = System.currentTimeMillis();
+                    long timestamp = TimeUtil.currentTimeMillis();
                     Transaction tx = new Transaction(network, type, to, value, fee, nonce, timestamp, rawData);
                     tx.sign(acc.getKey());
 

--- a/src/main/java/org/semux/net/NodeManager.java
+++ b/src/main/java/org/semux/net/NodeManager.java
@@ -28,6 +28,7 @@ import org.semux.Kernel;
 import org.semux.Network;
 import org.semux.config.Config;
 import org.semux.config.Constants;
+import org.semux.util.TimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -200,7 +201,7 @@ public class NodeManager {
 
         while ((node = deque.pollFirst()) != null && channelMgr.size() < config.netMaxOutboundConnections()) {
             Long lastTouch = lastConnect.getIfPresent(node);
-            long now = System.currentTimeMillis();
+            long now = TimeUtil.currentTimeMillis();
 
             if (!client.getNode().equals(node)
                     && !activeAddresses.contains(node.toAddress())

--- a/src/main/java/org/semux/net/SemuxP2pHandler.java
+++ b/src/main/java/org/semux/net/SemuxP2pHandler.java
@@ -48,6 +48,7 @@ import org.semux.net.msg.p2p.PingMessage;
 import org.semux.net.msg.p2p.PongMessage;
 import org.semux.net.msg.p2p.TransactionMessage;
 import org.semux.net.msg.p2p.WorldMessage;
+import org.semux.util.TimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -225,7 +226,7 @@ public class SemuxP2pHandler extends SimpleChannelInboundHandler<Message> {
         }
         case PONG: {
             if (mr != null) {
-                long latency = System.currentTimeMillis() - mr.getLastTimestamp();
+                long latency = TimeUtil.currentTimeMillis() - mr.getLastTimestamp();
                 channel.getRemotePeer().setLatency(latency);
             }
             break;

--- a/src/main/java/org/semux/net/filter/SemuxIpFilter.java
+++ b/src/main/java/org/semux/net/filter/SemuxIpFilter.java
@@ -164,7 +164,7 @@ public class SemuxIpFilter {
      *            the path where rules will be persisted at.
      */
     public void persist(Path path) {
-        new SemuxIpFilter.Saver().save(path, this);
+        new Saver().save(path, this);
     }
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
@@ -230,8 +230,8 @@ public class SemuxIpFilter {
     }
 
     /**
-     * ${@link SemuxIpFilter.Loader} is responsible for loading ipfilter.json file
-     * into an instance of SemuxIpFilter.
+     * ${@link Loader} is responsible for loading ipfilter.json file into an
+     * instance of SemuxIpFilter.
      */
     public static final class Loader {
 
@@ -252,7 +252,7 @@ public class SemuxIpFilter {
     }
 
     /**
-     * ${@link SemuxIpFilter.Saver} is responsible for persisting the state of a
+     * ${@link Saver} is responsible for persisting the state of a
      * ${@link SemuxIpFilter} instance.
      */
     public static final class Saver {

--- a/src/main/java/org/semux/net/msg/MessageWrapper.java
+++ b/src/main/java/org/semux/net/msg/MessageWrapper.java
@@ -6,6 +6,8 @@
  */
 package org.semux.net.msg;
 
+import org.semux.util.TimeUtil;
+
 /**
  * Utility that keeps track of the number of retries and lastTimestamp.
  *
@@ -29,7 +31,7 @@ public class MessageWrapper {
     }
 
     public void saveTime() {
-        lastTimestamp = System.currentTimeMillis();
+        lastTimestamp = TimeUtil.currentTimeMillis();
     }
 
     public void answer() {

--- a/src/main/java/org/semux/net/msg/p2p/HelloMessage.java
+++ b/src/main/java/org/semux/net/msg/p2p/HelloMessage.java
@@ -15,6 +15,7 @@ import org.semux.net.msg.Message;
 import org.semux.net.msg.MessageCode;
 import org.semux.util.SimpleDecoder;
 import org.semux.util.SimpleEncoder;
+import org.semux.util.TimeUtil;
 
 public class HelloMessage extends Message {
 
@@ -32,7 +33,7 @@ public class HelloMessage extends Message {
         super(MessageCode.HELLO, WorldMessage.class);
 
         this.peer = peer;
-        this.timestamp = System.currentTimeMillis();
+        this.timestamp = TimeUtil.currentTimeMillis();
 
         SimpleEncoder enc = new SimpleEncoder();
         enc.writeBytes(peer.toBytes());
@@ -73,7 +74,7 @@ public class HelloMessage extends Message {
      */
     public boolean validate(Config config) {
         if (peer != null && peer.validate()
-                && Math.abs(System.currentTimeMillis() - timestamp) <= config.netHandshakeExpiry()
+                && Math.abs(TimeUtil.currentTimeMillis() - timestamp) <= config.netHandshakeExpiry()
                 && signature != null
                 && peer.getPeerId().equals(Hex.encode(signature.getAddress()))) {
 

--- a/src/main/java/org/semux/net/msg/p2p/PingMessage.java
+++ b/src/main/java/org/semux/net/msg/p2p/PingMessage.java
@@ -10,6 +10,7 @@ import org.semux.net.msg.Message;
 import org.semux.net.msg.MessageCode;
 import org.semux.util.SimpleDecoder;
 import org.semux.util.SimpleEncoder;
+import org.semux.util.TimeUtil;
 
 public class PingMessage extends Message {
 
@@ -22,7 +23,7 @@ public class PingMessage extends Message {
     public PingMessage() {
         super(MessageCode.PING, PongMessage.class);
 
-        this.timestamp = System.currentTimeMillis();
+        this.timestamp = TimeUtil.currentTimeMillis();
 
         SimpleEncoder enc = new SimpleEncoder();
         enc.writeLong(timestamp);

--- a/src/main/java/org/semux/net/msg/p2p/PongMessage.java
+++ b/src/main/java/org/semux/net/msg/p2p/PongMessage.java
@@ -10,6 +10,7 @@ import org.semux.net.msg.Message;
 import org.semux.net.msg.MessageCode;
 import org.semux.util.SimpleDecoder;
 import org.semux.util.SimpleEncoder;
+import org.semux.util.TimeUtil;
 
 public class PongMessage extends Message {
 
@@ -21,7 +22,7 @@ public class PongMessage extends Message {
     public PongMessage() {
         super(MessageCode.PONG, null);
 
-        this.timestamp = System.currentTimeMillis();
+        this.timestamp = TimeUtil.currentTimeMillis();
 
         SimpleEncoder enc = new SimpleEncoder();
         enc.writeLong(timestamp);

--- a/src/main/java/org/semux/net/msg/p2p/WorldMessage.java
+++ b/src/main/java/org/semux/net/msg/p2p/WorldMessage.java
@@ -15,6 +15,7 @@ import org.semux.net.msg.Message;
 import org.semux.net.msg.MessageCode;
 import org.semux.util.SimpleDecoder;
 import org.semux.util.SimpleEncoder;
+import org.semux.util.TimeUtil;
 
 public class WorldMessage extends Message {
 
@@ -32,7 +33,7 @@ public class WorldMessage extends Message {
         super(MessageCode.WORLD, null);
 
         this.peer = peer;
-        this.timestamp = System.currentTimeMillis();
+        this.timestamp = TimeUtil.currentTimeMillis();
 
         SimpleEncoder enc = new SimpleEncoder();
         enc.writeBytes(peer.toBytes());
@@ -73,7 +74,7 @@ public class WorldMessage extends Message {
      */
     public boolean validate(Config config) {
         if (peer != null && peer.validate()
-                && Math.abs(System.currentTimeMillis() - timestamp) <= config.netHandshakeExpiry()
+                && Math.abs(TimeUtil.currentTimeMillis() - timestamp) <= config.netHandshakeExpiry()
                 && signature != null
                 && peer.getPeerId().equals(Hex.encode(signature.getAddress()))) {
 

--- a/src/main/java/org/semux/util/TimeUtil.java
+++ b/src/main/java/org/semux/util/TimeUtil.java
@@ -6,18 +6,51 @@
  */
 package org.semux.util;
 
+import org.apache.commons.net.ntp.NTPUDPClient;
+import org.apache.commons.net.ntp.TimeInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetAddress;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.util.Date;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class TimeUtil {
 
+    private static final Logger logger = LoggerFactory.getLogger(TimeUtil.class);
+    private static final ThreadFactory factory = new ThreadFactory() {
+        private AtomicInteger cnt = new AtomicInteger(0);
+
+        @Override
+        public Thread newThread(Runnable r) {
+            return new Thread(r, "ntpUpdate-" + cnt.getAndIncrement());
+        }
+    };
+
     public static final String DEFAULT_DURATION_FORMAT = "%02d:%02d:%02d";
     public static final String DEFAULT_TIMESTAMP_FORMAT = "yyyy-MM-dd HH:mm:ss";
+    public static final String NTP_POOL = "pool.ntp.org";
+    private static final ScheduledExecutorService ntpUpdateTimer = Executors.newSingleThreadScheduledExecutor(factory);
+
+    private static long timeOffsetFromNtp = 0;
+
+    static {
+        // inline run at start
+        updateNetworkTimeOffset();
+        // update time every hour
+        ntpUpdateTimer.scheduleAtFixedRate(TimeUtil::updateNetworkTimeOffset, 60 * 60 * 1000, 60, TimeUnit.MINUTES);
+    }
 
     /**
      * Returns a human-readable duration
-     * 
+     *
      * @param duration
      *            duration object to be formatted
      * @return formatted duration in 00:00:00
@@ -28,13 +61,41 @@ public class TimeUtil {
     }
 
     /**
-     *
      * @param timestamp
      *            timestamp in milliseconds to be formatter
      * @return formatted timestamp in yyyy-MM-dd HH:mm:ss
      */
     public static String formatTimestamp(Long timestamp) {
         return new SimpleDateFormat(DEFAULT_TIMESTAMP_FORMAT).format(new Date(timestamp));
+    }
+
+    public static long currentTimeMillis() {
+        return System.currentTimeMillis() + timeOffsetFromNtp;
+    }
+
+    /**
+     * Update time offset from NTP
+     */
+    private static void updateNetworkTimeOffset() {
+        NTPUDPClient client = new NTPUDPClient();
+        client.setDefaultTimeout(10000);
+        try {
+            client.open();
+            InetAddress hostAddr = InetAddress.getByName(NTP_POOL);
+            TimeInfo info = client.getTime(hostAddr);
+            info.computeDetails();
+
+            // update our current internal state
+            timeOffsetFromNtp = info.getOffset();
+        } catch (IOException e) {
+            logger.warn("Unable to retrieve NTP time", e);
+        } finally {
+            client.close();
+        }
+    }
+
+    public static long getTimeOffsetFromNtp() {
+        return timeOffsetFromNtp;
     }
 
     private TimeUtil() {

--- a/src/main/resources/org/semux/cli/messages.properties
+++ b/src/main/resources/org/semux/cli/messages.properties
@@ -31,3 +31,4 @@ CreateNewWalletError = Unable to create a new wallet.
 WrongPassword = Incorrect password
 WarningWalletPosixPermission = Your wallet.data file is not secured. Please set its permission level to 600.
 WarningConfigPosixPermission = Your semux.properties config file is not secured. Please set its permission level to 600.
+SystemTimeDrift = Your system time is out of sync! Please check your time.

--- a/src/test/java/org/semux/TestUtils.java
+++ b/src/test/java/org/semux/TestUtils.java
@@ -19,6 +19,7 @@ import org.semux.core.TransactionType;
 import org.semux.crypto.Key;
 import org.semux.util.Bytes;
 import org.semux.util.MerkleUtil;
+import org.semux.util.TimeUtil;
 
 public class TestUtils {
 
@@ -28,7 +29,7 @@ public class TestUtils {
 
     public static Block createBlock(byte[] prevHash, Key coinbase, long number, List<Transaction> txs,
             List<TransactionResult> res) {
-        long timestamp = System.currentTimeMillis();
+        long timestamp = TimeUtil.currentTimeMillis();
         byte[] transactionsRoot = MerkleUtil.computeTransactionsRoot(txs);
         byte[] resultsRoot = MerkleUtil.computeResultsRoot(res);
         byte[] stateRoot = Bytes.EMPTY_HASH;
@@ -56,7 +57,7 @@ public class TestUtils {
         Network network = config.network();
         TransactionType type = TransactionType.TRANSFER;
         Amount fee = config.minTransactionFee();
-        long timestamp = System.currentTimeMillis();
+        long timestamp = TimeUtil.currentTimeMillis();
         byte[] data = {};
 
         return new Transaction(network, type, to.toAddress(), value, fee, nonce, timestamp, data).sign(from);

--- a/src/test/java/org/semux/bench/BlockchainPerformance.java
+++ b/src/test/java/org/semux/bench/BlockchainPerformance.java
@@ -30,6 +30,7 @@ import org.semux.crypto.Key.Signature;
 import org.semux.rules.TemporaryDatabaseRule;
 import org.semux.util.Bytes;
 import org.semux.util.MerkleUtil;
+import org.semux.util.TimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +54,7 @@ public class BlockchainPerformance {
             Amount value = NANO_SEM.of(1);
             Amount fee = config.minTransactionFee();
             long nonce = 1 + i;
-            long timestamp = System.currentTimeMillis();
+            long timestamp = TimeUtil.currentTimeMillis();
             byte[] data = Bytes.EMPTY_BYTES;
             Transaction tx = new Transaction(network, type, to, value, fee, nonce, timestamp, data).sign(key);
 
@@ -69,7 +70,7 @@ public class BlockchainPerformance {
         long number = 1;
         byte[] coinbase = key.toAddress();
         byte[] prevHash = Bytes.random(32);
-        long timestamp = System.currentTimeMillis();
+        long timestamp = TimeUtil.currentTimeMillis();
         byte[] transactionsRoot = MerkleUtil.computeTransactionsRoot(txs);
         byte[] resultsRoot = MerkleUtil.computeResultsRoot(res);
         byte[] stateRoot = Bytes.EMPTY_HASH;
@@ -119,7 +120,7 @@ public class BlockchainPerformance {
         Amount value = NANO_SEM.of(1);
         Amount fee = config.minTransactionFee();
         long nonce = 1;
-        long timestamp = System.currentTimeMillis();
+        long timestamp = TimeUtil.currentTimeMillis();
         byte[] data = {};
         Transaction tx = new Transaction(network, type, to, value, fee, nonce, timestamp, data);
         tx.sign(key);
@@ -144,11 +145,11 @@ public class BlockchainPerformance {
         TemporaryDatabaseRule temporaryDbRule = new TemporaryDatabaseRule();
         temporaryDbRule.before();
         Blockchain blockchain = new BlockchainImpl(config, temporaryDbRule);
-        long t1 = System.currentTimeMillis();
+        long t1 = TimeUtil.currentTimeMillis();
         for (int i = 0; i < repeat; i++) {
             blockchain.addBlock(blocks[i]);
         }
-        long t2 = System.currentTimeMillis();
+        long t2 = TimeUtil.currentTimeMillis();
         temporaryDbRule.after();
         logger.info("Perf_addBlock: {} ms / {} blocks", t2 - t1, repeat);
     }

--- a/src/test/java/org/semux/bench/SemuxPerformance.java
+++ b/src/test/java/org/semux/bench/SemuxPerformance.java
@@ -20,6 +20,7 @@ import org.semux.config.DevnetConfig;
 import org.semux.util.ApiClient;
 import org.semux.util.Bytes;
 import org.semux.util.ConsoleUtil;
+import org.semux.util.TimeUtil;
 
 public class SemuxPerformance {
     private static InetSocketAddress server = new InetSocketAddress("127.0.0.1", 5171);
@@ -32,7 +33,7 @@ public class SemuxPerformance {
     public static void testTransfer(int n) throws IOException, InterruptedException {
         DevnetConfig config = new DevnetConfig(Constants.DEFAULT_DATA_DIR);
 
-        long t1 = System.currentTimeMillis();
+        long t1 = TimeUtil.currentTimeMillis();
         for (int i = 1; i <= n; i++) {
             Map<String, Object> params = new HashMap<>();
             params.put("from", address);
@@ -51,7 +52,7 @@ public class SemuxPerformance {
 
             if (i % tps == 0) {
                 System.out.println(new SimpleDateFormat("[HH:mm:ss]").format(new Date()) + " " + i);
-                long t2 = System.currentTimeMillis();
+                long t2 = TimeUtil.currentTimeMillis();
                 Thread.sleep(Math.max(0, 1000 - (t2 - t1)));
                 t1 = t2;
             }

--- a/src/test/java/org/semux/consensus/ProposalTest.java
+++ b/src/test/java/org/semux/consensus/ProposalTest.java
@@ -27,6 +27,7 @@ import org.semux.core.TransactionResult;
 import org.semux.core.TransactionType;
 import org.semux.crypto.Key;
 import org.semux.util.Bytes;
+import org.semux.util.TimeUtil;
 
 public class ProposalTest {
 
@@ -38,7 +39,7 @@ public class ProposalTest {
         Amount value = NANO_SEM.of(2);
         Amount fee = NANO_SEM.of(50_000_000L);
         long nonce = 1;
-        long timestamp = System.currentTimeMillis();
+        long timestamp = TimeUtil.currentTimeMillis();
         byte[] data = Bytes.of("data");
 
         Transaction tx = new Transaction(network, type, to, value, fee, nonce, timestamp, data);

--- a/src/test/java/org/semux/consensus/SemuxBftTest.java
+++ b/src/test/java/org/semux/consensus/SemuxBftTest.java
@@ -44,6 +44,7 @@ import org.semux.crypto.Key;
 import org.semux.rules.KernelRule;
 import org.semux.rules.TemporaryDatabaseRule;
 import org.semux.util.Bytes;
+import org.semux.util.TimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -118,7 +119,7 @@ public class SemuxBftTest {
         // mock blockchain with a single transaction
         Key to = new Key();
         Key from1 = new Key();
-        long time = System.currentTimeMillis();
+        long time = TimeUtil.currentTimeMillis();
         Transaction tx1 = createTransaction(to, from1, time, 0);
         kernelRule.getKernel().setBlockchain(new BlockchainImpl(kernelRule.getKernel().getConfig(), temporaryDBRule));
         kernelRule.getKernel().getBlockchain().getAccountState().adjustAvailable(from1.toAddress(), SEM.of(1000));
@@ -156,7 +157,7 @@ public class SemuxBftTest {
     public void testFilterPendingTransactions() {
         Key to = new Key();
         Key from = new Key();
-        long time = System.currentTimeMillis();
+        long time = TimeUtil.currentTimeMillis();
         Transaction tx1 = createTransaction(to, from, time, 0);
         Transaction tx2 = createTransaction(to, from, time, 1);
 

--- a/src/test/java/org/semux/consensus/SemuxBftValidateBlockTest.java
+++ b/src/test/java/org/semux/consensus/SemuxBftValidateBlockTest.java
@@ -33,6 +33,7 @@ import org.semux.core.Block;
 import org.semux.core.BlockHeader;
 import org.semux.core.Blockchain;
 import org.semux.core.Transaction;
+import org.semux.util.TimeUtil;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ Block.class, System.class })
@@ -63,7 +64,7 @@ public class SemuxBftValidateBlockTest {
                         (Supplier<BlockHeader>) () -> {
                             BlockHeader blockHeader = mock(BlockHeader.class);
                             when(blockHeader.getTimestamp())
-                                    .thenReturn(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1));
+                                    .thenReturn(TimeUtil.currentTimeMillis() + TimeUnit.DAYS.toMillis(1));
                             return blockHeader;
                         },
                         (Supplier<List<Transaction>>) ArrayList::new,

--- a/src/test/java/org/semux/consensus/SemuxSyncTest.java
+++ b/src/test/java/org/semux/consensus/SemuxSyncTest.java
@@ -45,6 +45,7 @@ import org.semux.crypto.Key;
 import org.semux.rules.KernelRule;
 import org.semux.rules.TemporaryDatabaseRule;
 import org.semux.util.Bytes;
+import org.semux.util.TimeUtil;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class SemuxSyncTest {
@@ -60,7 +61,7 @@ public class SemuxSyncTest {
         // mock blockchain with a single transaction
         Key to = new Key();
         Key from1 = new Key();
-        long time = System.currentTimeMillis();
+        long time = TimeUtil.currentTimeMillis();
         Transaction tx1 = new Transaction(
                 kernelRule.getKernel().getConfig().network(),
                 TransactionType.TRANSFER,

--- a/src/test/java/org/semux/consensus/VoteTest.java
+++ b/src/test/java/org/semux/consensus/VoteTest.java
@@ -24,6 +24,7 @@ import org.semux.crypto.Key;
 import org.semux.util.ByteArray;
 import org.semux.util.Bytes;
 import org.semux.util.MerkleUtil;
+import org.semux.util.TimeUtil;
 
 public class VoteTest {
 
@@ -70,7 +71,7 @@ public class VoteTest {
         long number = 1;
         byte[] coinbase = key1.toAddress();
         byte[] prevHash = Bytes.EMPTY_HASH;
-        long timestamp = System.currentTimeMillis();
+        long timestamp = TimeUtil.currentTimeMillis();
         byte[] transactionsRoot = MerkleUtil.computeTransactionsRoot(transactions);
         byte[] resultsRoot = MerkleUtil.computeResultsRoot(results);
         byte[] stateRoot = Bytes.EMPTY_HASH;

--- a/src/test/java/org/semux/core/BlockHeaderTest.java
+++ b/src/test/java/org/semux/core/BlockHeaderTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.semux.config.Constants;
 import org.semux.util.Bytes;
+import org.semux.util.TimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,7 +22,7 @@ public class BlockHeaderTest {
     private long number = 1;
     private byte[] coinbase = Bytes.random(20);
     private byte[] prevHash = Bytes.random(32);
-    private long timestamp = System.currentTimeMillis();
+    private long timestamp = TimeUtil.currentTimeMillis();
     private byte[] transactionsRoot = Bytes.random(32);
     private byte[] resultsRoot = Bytes.random(32);
     private byte[] stateRoot = Bytes.random(32);

--- a/src/test/java/org/semux/core/BlockTest.java
+++ b/src/test/java/org/semux/core/BlockTest.java
@@ -26,6 +26,7 @@ import org.semux.crypto.Key.Signature;
 import org.semux.util.Bytes;
 import org.semux.util.MerkleUtil;
 import org.semux.util.SimpleDecoder;
+import org.semux.util.TimeUtil;
 
 public class BlockTest {
 
@@ -34,12 +35,12 @@ public class BlockTest {
     private long number = 5;
     private byte[] coinbase = Bytes.random(20);
     private byte[] prevHash = Bytes.random(32);
-    private long timestamp = System.currentTimeMillis();
+    private long timestamp = TimeUtil.currentTimeMillis();
     private byte[] data = Bytes.of("data");
 
     private Transaction tx = new Transaction(Network.DEVNET, TransactionType.TRANSFER, Bytes.random(20), ZERO,
             config.minTransactionFee(),
-            1, System.currentTimeMillis(), Bytes.EMPTY_BYTES).sign(new Key());
+            1, TimeUtil.currentTimeMillis(), Bytes.EMPTY_BYTES).sign(new Key());
     private TransactionResult res = new TransactionResult(true);
     private List<Transaction> transactions = Collections.singletonList(tx);
     private List<TransactionResult> results = Collections.singletonList(res);

--- a/src/test/java/org/semux/core/BlockchainImplTest.java
+++ b/src/test/java/org/semux/core/BlockchainImplTest.java
@@ -33,6 +33,7 @@ import org.semux.crypto.Key;
 import org.semux.rules.TemporaryDatabaseRule;
 import org.semux.util.Bytes;
 import org.semux.util.MerkleUtil;
+import org.semux.util.TimeUtil;
 
 public class BlockchainImplTest {
 
@@ -53,7 +54,7 @@ public class BlockchainImplTest {
     private Amount fee = NANO_SEM.of(1);
     private long nonce = 12345;
     private byte[] data = Bytes.of("test");
-    private long timestamp = System.currentTimeMillis() - 60 * 1000;
+    private long timestamp = TimeUtil.currentTimeMillis() - 60 * 1000;
     private Transaction tx = new Transaction(network, TransactionType.TRANSFER, to, value, fee, nonce, timestamp,
             data)
                     .sign(key);
@@ -336,7 +337,7 @@ public class BlockchainImplTest {
         byte[] transactionsRoot = MerkleUtil.computeTransactionsRoot(transactions);
         byte[] resultsRoot = MerkleUtil.computeResultsRoot(results);
         byte[] stateRoot = Bytes.EMPTY_HASH;
-        long timestamp = System.currentTimeMillis();
+        long timestamp = TimeUtil.currentTimeMillis();
 
         BlockHeader header = new BlockHeader(number, coinbase, prevHash, timestamp, transactionsRoot, resultsRoot,
                 stateRoot, data);

--- a/src/test/java/org/semux/core/CorePerformanceTest.java
+++ b/src/test/java/org/semux/core/CorePerformanceTest.java
@@ -23,6 +23,7 @@ import org.semux.core.state.Delegate;
 import org.semux.crypto.Key;
 import org.semux.rules.TemporaryDatabaseRule;
 import org.semux.util.Bytes;
+import org.semux.util.TimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +66,7 @@ public class CorePerformanceTest {
             Amount value = NANO_SEM.of(5);
             Amount fee = config.minTransactionFee();
             long nonce = 1;
-            long timestamp = System.currentTimeMillis();
+            long timestamp = TimeUtil.currentTimeMillis();
             byte[] data = Bytes.random(16);
 
             Transaction tx = new Transaction(Network.DEVNET, type, to, value, fee, nonce, timestamp, data);

--- a/src/test/java/org/semux/core/PendingManagerTest.java
+++ b/src/test/java/org/semux/core/PendingManagerTest.java
@@ -36,6 +36,7 @@ import org.semux.net.ChannelManager;
 import org.semux.rules.KernelRule;
 import org.semux.util.ArrayUtil;
 import org.semux.util.Bytes;
+import org.semux.util.TimeUtil;
 
 public class PendingManagerTest {
 
@@ -78,7 +79,7 @@ public class PendingManagerTest {
 
     @Test
     public void testGetTransaction() throws InterruptedException {
-        long now = System.currentTimeMillis();
+        long now = TimeUtil.currentTimeMillis();
         long nonce = accountState.getAccount(from).getNonce();
 
         Transaction tx = new Transaction(network, type, to, value, fee, nonce, now, Bytes.EMPTY_BYTES).sign(key);
@@ -90,7 +91,7 @@ public class PendingManagerTest {
 
     @Test
     public void testAddTransaction() throws InterruptedException {
-        long now = System.currentTimeMillis();
+        long now = TimeUtil.currentTimeMillis();
         long nonce = accountState.getAccount(from).getNonce();
 
         Transaction tx = new Transaction(network, type, to, value, fee, nonce, now, Bytes.EMPTY_BYTES).sign(key);
@@ -114,7 +115,7 @@ public class PendingManagerTest {
 
     @Test
     public void testAddTransactionSyncErrorDuplicatedHash() {
-        Transaction tx = new Transaction(network, type, to, value, fee, 0, System.currentTimeMillis(),
+        Transaction tx = new Transaction(network, type, to, value, fee, 0, TimeUtil.currentTimeMillis(),
                 Bytes.EMPTY_BYTES)
                         .sign(key);
 
@@ -132,7 +133,7 @@ public class PendingManagerTest {
     @Test
     public void testAddTransactionSyncInvalidRecipient() {
         Transaction tx = new Transaction(network, type, Constants.COINBASE_KEY.toAddress(), value, fee, 0,
-                System.currentTimeMillis(),
+                TimeUtil.currentTimeMillis(),
                 Bytes.EMPTY_BYTES)
                         .sign(key);
 
@@ -144,7 +145,7 @@ public class PendingManagerTest {
 
     @Test
     public void testNonceJump() throws InterruptedException {
-        long now = System.currentTimeMillis();
+        long now = TimeUtil.currentTimeMillis();
         long nonce = accountState.getAccount(from).getNonce();
 
         Transaction tx3 = new Transaction(network, type, to, value, fee, nonce + 2, now, Bytes.EMPTY_BYTES).sign(key);
@@ -164,7 +165,7 @@ public class PendingManagerTest {
 
     @Test
     public void testNonceJumpTimestampError() throws InterruptedException {
-        long now = System.currentTimeMillis();
+        long now = TimeUtil.currentTimeMillis();
         long nonce = accountState.getAccount(from).getNonce();
 
         Transaction tx3 = new Transaction(network, type, to, value, fee, nonce + 2,
@@ -187,7 +188,7 @@ public class PendingManagerTest {
 
     @Test
     public void testTimestampError() {
-        long now = System.currentTimeMillis();
+        long now = TimeUtil.currentTimeMillis();
         long nonce = accountState.getAccount(from).getNonce();
 
         Transaction tx3 = new Transaction(network, type, to, value, fee, nonce, now - ALLOWED_TIME_DRIFT - 1,
@@ -198,7 +199,7 @@ public class PendingManagerTest {
 
     @Test
     public void testHighVolumeTransaction() throws InterruptedException {
-        long now = System.currentTimeMillis();
+        long now = TimeUtil.currentTimeMillis();
         long nonce = accountState.getAccount(from).getNonce();
 
         int[] perm = ArrayUtil.permutation(5000);
@@ -214,7 +215,7 @@ public class PendingManagerTest {
 
     @Test
     public void testNewBlock() throws InterruptedException {
-        long now = System.currentTimeMillis();
+        long now = TimeUtil.currentTimeMillis();
         long nonce = accountState.getAccount(from).getNonce();
 
         Transaction tx = new Transaction(network, type, to, value, fee, nonce, now, Bytes.EMPTY_BYTES).sign(key);
@@ -228,7 +229,7 @@ public class PendingManagerTest {
         long number = 1;
         byte[] coinbase = Bytes.random(20);
         byte[] prevHash = Bytes.random(20);
-        long timestamp = System.currentTimeMillis();
+        long timestamp = TimeUtil.currentTimeMillis();
         byte[] transactionsRoot = Bytes.random(32);
         byte[] resultsRoot = Bytes.random(32);
         byte[] stateRoot = Bytes.random(32);

--- a/src/test/java/org/semux/core/TransactionExecutorTest.java
+++ b/src/test/java/org/semux/core/TransactionExecutorTest.java
@@ -30,6 +30,7 @@ import org.semux.core.state.DelegateState;
 import org.semux.crypto.Key;
 import org.semux.rules.TemporaryDatabaseRule;
 import org.semux.util.Bytes;
+import org.semux.util.TimeUtil;
 
 public class TransactionExecutorTest {
 
@@ -72,7 +73,7 @@ public class TransactionExecutorTest {
         Amount value = NANO_SEM.of(5);
         Amount fee = config.minTransactionFee();
         long nonce = as.getAccount(from).getNonce();
-        long timestamp = System.currentTimeMillis();
+        long timestamp = TimeUtil.currentTimeMillis();
         byte[] data = Bytes.random(16);
 
         Transaction tx = new Transaction(network, type, to, value, fee, nonce, timestamp, data);
@@ -112,7 +113,7 @@ public class TransactionExecutorTest {
         Amount value = config.minDelegateBurnAmount();
         Amount fee = config.minTransactionFee();
         long nonce = as.getAccount(from).getNonce();
-        long timestamp = System.currentTimeMillis();
+        long timestamp = TimeUtil.currentTimeMillis();
         byte[] data = Bytes.random(16);
 
         // register delegate (to != EMPTY_ADDRESS, random name)
@@ -150,7 +151,7 @@ public class TransactionExecutorTest {
         Amount value = SEM.of(33);
         Amount fee = config.minTransactionFee();
         long nonce = as.getAccount(from).getNonce();
-        long timestamp = System.currentTimeMillis();
+        long timestamp = TimeUtil.currentTimeMillis();
         byte[] data = {};
 
         // vote for non-existing delegate
@@ -184,7 +185,7 @@ public class TransactionExecutorTest {
         Amount value = SEM.of(33);
         Amount fee = config.minTransactionFee();
         long nonce = as.getAccount(from).getNonce();
-        long timestamp = System.currentTimeMillis();
+        long timestamp = TimeUtil.currentTimeMillis();
         byte[] data = {};
 
         // unvote (never voted before)
@@ -223,7 +224,7 @@ public class TransactionExecutorTest {
         Amount value = SEM.of(100);
         Amount fee = config.minTransactionFee();
         long nonce = as.getAccount(from).getNonce();
-        long timestamp = System.currentTimeMillis();
+        long timestamp = TimeUtil.currentTimeMillis();
         byte[] data = {};
 
         // unvote (never voted before)

--- a/src/test/java/org/semux/gui/dialog/ConsoleDialogTest.java
+++ b/src/test/java/org/semux/gui/dialog/ConsoleDialogTest.java
@@ -33,6 +33,7 @@ import org.semux.core.TransactionResult;
 import org.semux.gui.model.WalletModel;
 import org.semux.rules.KernelRule;
 import org.semux.util.Bytes;
+import org.semux.util.TimeUtil;
 
 /**
  */
@@ -83,7 +84,7 @@ public class ConsoleDialogTest extends AssertJSwingJUnitTestCase {
         long number = 1;
         byte[] coinbase = Bytes.random(20);
         byte[] prevHash = Bytes.random(20);
-        long timestamp = System.currentTimeMillis();
+        long timestamp = TimeUtil.currentTimeMillis();
         byte[] transactionsRoot = Bytes.random(32);
         byte[] resultsRoot = Bytes.random(32);
         byte[] stateRoot = Bytes.random(32);

--- a/src/test/java/org/semux/gui/panel/TransactionsPanelTest.java
+++ b/src/test/java/org/semux/gui/panel/TransactionsPanelTest.java
@@ -39,6 +39,7 @@ import org.semux.gui.model.WalletModel;
 import org.semux.message.GuiMessages;
 import org.semux.rules.KernelRule;
 import org.semux.util.Bytes;
+import org.semux.util.TimeUtil;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TransactionsPanelTest extends AssertJSwingJUnitTestCase {
@@ -70,7 +71,7 @@ public class TransactionsPanelTest extends AssertJSwingJUnitTestCase {
                 SEM.of(1),
                 MILLI_SEM.of(10),
                 0,
-                System.currentTimeMillis(),
+                TimeUtil.currentTimeMillis(),
                 Bytes.EMPTY_BYTES);
         tx.sign(new Key());
         acc.setTransactions(Collections.singletonList(tx));

--- a/src/test/java/org/semux/net/msg/consensus/BlockHeaderMessageTest.java
+++ b/src/test/java/org/semux/net/msg/consensus/BlockHeaderMessageTest.java
@@ -16,6 +16,7 @@ import org.semux.crypto.Key;
 import org.semux.net.msg.MessageCode;
 import org.semux.util.Bytes;
 import org.semux.util.MerkleUtil;
+import org.semux.util.TimeUtil;
 
 public class BlockHeaderMessageTest {
 
@@ -24,7 +25,7 @@ public class BlockHeaderMessageTest {
         long number = 1;
         byte[] coinbase = Bytes.random(Key.ADDRESS_LEN);
         byte[] prevHash = Bytes.random(32);
-        long timestamp = System.currentTimeMillis();
+        long timestamp = TimeUtil.currentTimeMillis();
         byte[] transactionsRoot = MerkleUtil.computeTransactionsRoot(Collections.emptyList());
         byte[] resultsRoot = MerkleUtil.computeResultsRoot(Collections.emptyList());
         byte[] stateRoot = Bytes.EMPTY_HASH;

--- a/src/test/java/org/semux/net/msg/consensus/ProposalMessageTest.java
+++ b/src/test/java/org/semux/net/msg/consensus/ProposalMessageTest.java
@@ -17,6 +17,7 @@ import org.semux.core.BlockHeader;
 import org.semux.crypto.Key;
 import org.semux.util.Bytes;
 import org.semux.util.MerkleUtil;
+import org.semux.util.TimeUtil;
 
 public class ProposalMessageTest {
     @Test
@@ -28,7 +29,7 @@ public class ProposalMessageTest {
         long number = 1;
         byte[] coinbase = Bytes.random(Key.ADDRESS_LEN);
         byte[] prevHash = Bytes.random(32);
-        long timestamp = System.currentTimeMillis();
+        long timestamp = TimeUtil.currentTimeMillis();
         byte[] transactionsRoot = MerkleUtil.computeTransactionsRoot(Collections.emptyList());
         byte[] resultsRoot = MerkleUtil.computeResultsRoot(Collections.emptyList());
         byte[] stateRoot = Bytes.EMPTY_HASH;

--- a/src/test/java/org/semux/net/msg/p2p/TransactionMessageTest.java
+++ b/src/test/java/org/semux/net/msg/p2p/TransactionMessageTest.java
@@ -17,6 +17,7 @@ import org.semux.core.Transaction;
 import org.semux.core.TransactionType;
 import org.semux.crypto.Key;
 import org.semux.util.Bytes;
+import org.semux.util.TimeUtil;
 
 public class TransactionMessageTest {
     @Test
@@ -27,7 +28,7 @@ public class TransactionMessageTest {
         Amount value = NANO_SEM.of(2);
         Amount fee = NANO_SEM.of(50_000_000L);
         long nonce = 1;
-        long timestamp = System.currentTimeMillis();
+        long timestamp = TimeUtil.currentTimeMillis();
         byte[] data = Bytes.of("data");
 
         Transaction tx = new Transaction(network, type, to, value, fee, nonce, timestamp, data);

--- a/src/test/java/org/semux/rules/KernelRule.java
+++ b/src/test/java/org/semux/rules/KernelRule.java
@@ -32,6 +32,7 @@ import org.semux.crypto.Key;
 import org.semux.db.LeveldbDatabase.LeveldbFactory;
 import org.semux.util.Bytes;
 import org.semux.util.MerkleUtil;
+import org.semux.util.TimeUtil;
 
 /**
  * A kernel rule creates a temporary folder as the data directory. Ten accounts
@@ -158,7 +159,7 @@ public class KernelRule extends TemporaryFolder {
         Key key = new Key();
         byte[] coinbase = key.toAddress();
         byte[] prevHash = getKernel().getBlockchain().getLatestBlock().getHash();
-        long timestamp = System.currentTimeMillis();
+        long timestamp = TimeUtil.currentTimeMillis();
         byte[] transactionsRoot = MerkleUtil.computeTransactionsRoot(txs);
         byte[] resultsRoot = MerkleUtil.computeResultsRoot(res);
         byte[] stateRoot = Bytes.EMPTY_HASH;

--- a/src/test/java/org/semux/util/MerkleUtilTest.java
+++ b/src/test/java/org/semux/util/MerkleUtilTest.java
@@ -32,7 +32,7 @@ public class MerkleUtilTest {
         Amount value = SEM.of(1);
         Amount fee = ZERO;
         long nonce = 1;
-        long timestamp = System.currentTimeMillis();
+        long timestamp = TimeUtil.currentTimeMillis();
         byte[] data = Bytes.random(128);
         Transaction tx1 = new Transaction(network, type, to, value, fee, nonce, timestamp, data).sign(new Key());
         Transaction tx2 = new Transaction(network, type, to, value, fee, nonce, timestamp, data).sign(new Key());

--- a/src/test/java/org/semux/util/TimeUtilTest.java
+++ b/src/test/java/org/semux/util/TimeUtilTest.java
@@ -11,7 +11,9 @@ import static org.junit.Assert.assertTrue;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -37,5 +39,13 @@ public class TimeUtilTest {
     @Test
     public void testFormatDuration() {
         assertTrue(TimeUtil.formatDuration(duration).equals(formatted));
+    }
+
+    @Test
+    public void testNtpTime() {
+        long currentTime = System.currentTimeMillis();
+        long offset = TimeUtil.getTimeOffsetFromNtp();
+        // ensure the time is within the actual time offset.
+        Assert.assertTrue(Math.abs(currentTime + offset - TimeUtil.currentTimeMillis()) < 1000);
     }
 }

--- a/src/test/java/org/semux/util/TimeUtilTest.java
+++ b/src/test/java/org/semux/util/TimeUtilTest.java
@@ -11,7 +11,6 @@ import static org.junit.Assert.assertTrue;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/src/test/java/org/semux/windows/Launch4jWrapperIT.java
+++ b/src/test/java/org/semux/windows/Launch4jWrapperIT.java
@@ -22,7 +22,7 @@ import org.junit.experimental.categories.Category;
 import org.semux.util.SystemUtil;
 import org.semux.util.SystemUtil.OsName;
 
-@Category(org.semux.windows.WindowsIntegrationTest.class)
+@Category(WindowsIntegrationTest.class)
 public class Launch4jWrapperIT {
 
     private Process l4jWrapper;


### PR DESCRIPTION
Use NTP time from server lookup.  Update NTP time every hour.
If failure to lookup time, still will default to system time.

This does add some overhead, as we will need to be mindful to use
TimeUtil.systemCurrentTimeMillis() instead of
System.currentTimeMillis()

For ease of managing, even trivial usages (e.g. logging
statements) have been migrated.

Apologies, as re-importing the old CR caused IDE to do some
auto-formatting.  Looks like just removed unnecessary static imports.