### PR TITLE
 GUI: Fix account list ordering in send panel

### DIFF
--- a/src/main/java/org/semux/gui/panel/SendPanel.java
+++ b/src/main/java/org/semux/gui/panel/SendPanel.java
@@ -14,6 +14,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.text.ParseException;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -308,7 +309,7 @@ public class SendPanel extends JPanel implements ActionListener {
     protected void refresh() {
         List<WalletAccount> list = model.getAccounts();
 
-        Set<AccountItem> accountItems = new TreeSet<>();
+        Set<AccountItem> accountItems = new LinkedHashSet<>();
         for (WalletAccount aList : list) {
             AccountItem accountItem = new AccountItem(aList);
             accountItems.add(accountItem);

--- a/src/main/java/org/semux/gui/panel/SendPanel.java
+++ b/src/main/java/org/semux/gui/panel/SendPanel.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeSet;
 
 import javax.swing.ButtonGroup;
 import javax.swing.GroupLayout;

--- a/src/main/java/org/semux/gui/panel/SendPanel.java
+++ b/src/main/java/org/semux/gui/panel/SendPanel.java
@@ -13,12 +13,11 @@ import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import javax.swing.ButtonGroup;
 import javax.swing.GroupLayout;
@@ -308,7 +307,7 @@ public class SendPanel extends JPanel implements ActionListener {
     protected void refresh() {
         List<WalletAccount> list = model.getAccounts();
 
-        Set<AccountItem> accountItems = new LinkedHashSet<>();
+        List<AccountItem> accountItems = new ArrayList<>();
         for (WalletAccount aList : list) {
             AccountItem accountItem = new AccountItem(aList);
             accountItems.add(accountItem);


### PR DESCRIPTION
Re-fix the account panel so send panel to/from are in same order
as account list, for users that do not name their accounts.