### PR TITLE
Net: Inform user of failure to sync due to Peer exception

### DIFF
--- a/src/main/java/org/semux/net/SemuxP2pHandler.java
+++ b/src/main/java/org/semux/net/SemuxP2pHandler.java
@@ -155,8 +155,15 @@ public class SemuxP2pHandler extends SimpleChannelInboundHandler<Message> {
         switch (msg.getCode()) {
         /* p2p */
         case DISCONNECT: {
+            ReasonCode reason = ((DisconnectMessage) msg).getReason();
             logger.debug("Received DISCONNECT message: reason = {}, remoteIP = {}",
-                    ((DisconnectMessage) msg).getReason(), channel.getRemoteIp());
+                    reason, channel.getRemoteIp());
+
+            // Users often get confused with no logging why they are unable to sync
+            if (reason.equals(ReasonCode.INVALID_HANDSHAKE)) {
+                logger.warn("Disconnected from peer due to invalid handshake.  The most common cause of this is"
+                        + " using a proxy/VPN.  If this is the case, please set 'p2p.declaredIp' in configuration.");
+            }
             stopTimers();
             ctx.close();
             break;


### PR DESCRIPTION
We have many users that are unable to determine why they are unable to
sync.  It is often due to using a proxy/VPN, and some oddities in
which IP address to use.

I feel it is appropriate to at least give users a clear message as to
why the failure is occurring.

This can be replaced in the future with a better lookup mechanism.
I am open to alternatives.  Currently we do not have granularity to
determine why the peer is invalid, but we may want to give a specific
error code, rather than a general 'invalidpeer' message on denial.