### PR TITLE
Tests: use start() instead of run() for thread

### DIFF
--- a/src/test/java/org/semux/event/PubSubTest.java
+++ b/src/test/java/org/semux/event/PubSubTest.java
@@ -41,10 +41,10 @@ public class PubSubTest {
         pubSub.subscribe(event -> dispatched1.incrementAndGet(), TestEvent1.class);
         pubSub.subscribe(event -> dispatched2.incrementAndGet(), TestEvent2.class);
         for (int i = 0; i < fuzz1; i++) {
-            new Thread(() -> pubSub.publish(new TestEvent1())).run();
+            new Thread(() -> pubSub.publish(new TestEvent1())).start();
         }
         for (int i = 0; i < fuzz2; i++) {
-            new Thread(() -> pubSub.publish(new TestEvent2())).run();
+            new Thread(() -> pubSub.publish(new TestEvent2())).start();
         }
         await().atMost(30, TimeUnit.SECONDS).until(() -> dispatched1.get() == fuzz1);
         await().atMost(30, TimeUnit.SECONDS).until(() -> dispatched2.get() == fuzz2);


### PR DESCRIPTION
calling run() just runs it inline, negating purpose
of using thread.

Use start() so it runs threaded.