### PR TITLE
P2P: clean up message codec

### DIFF
--- a/src/main/java/org/semux/core/Block.java
+++ b/src/main/java/org/semux/core/Block.java
@@ -371,7 +371,7 @@ public class Block {
      *
      * @return
      */
-    public byte[] toBytesHeader() {
+    public byte[] getEncodedHeader() {
         return encodedHeader;
     }
 
@@ -380,7 +380,7 @@ public class Block {
      *
      * @return
      */
-    public byte[] toBytesTransactions() {
+    public byte[] getEncodedTransactions() {
         return encodedTransactions;
     }
 
@@ -389,7 +389,7 @@ public class Block {
      *
      * @return
      */
-    public byte[] toBytesResults() {
+    public byte[] getEncodedResults() {
         return encodedResults;
     }
 
@@ -398,7 +398,7 @@ public class Block {
      *
      * @return
      */
-    public byte[] toBytesVotes() {
+    public byte[] getEncodedVotes() {
         SimpleEncoder enc = new SimpleEncoder();
 
         enc.writeInt(view);
@@ -408,15 +408,6 @@ public class Block {
         }
 
         return enc.toBytes();
-    }
-
-    /**
-     * Get block size in bytes
-     *
-     * @return block size in bytes
-     */
-    public int size() {
-        return toBytesHeader().length + toBytesTransactions().length + toBytesResults().length + toBytesVotes().length;
     }
 
     /**
@@ -432,7 +423,7 @@ public class Block {
      *            Serialized votes
      * @return
      */
-    public static Block fromBytes(byte[] h, byte[] t, byte[] r, byte[] v) {
+    public static Block fromComponents(byte[] h, byte[] t, byte[] r, byte[] v) {
         BlockHeader header = BlockHeader.fromBytes(h);
 
         SimpleDecoder dec = new SimpleDecoder(t);
@@ -464,8 +455,33 @@ public class Block {
         return new Block(header, transactions, results, view, votes);
     }
 
-    public static Block fromBytes(byte[] h, byte[] t, byte[] r) {
-        return fromBytes(h, t, r, null);
+    public byte[] toBytes() {
+        SimpleEncoder enc = new SimpleEncoder();
+        enc.writeBytes(getEncodedHeader());
+        enc.writeBytes(getEncodedTransactions());
+        enc.writeBytes(getEncodedResults());
+        enc.writeBytes(getEncodedVotes());
+
+        return enc.toBytes();
+    }
+
+    public static Block fromBytes(byte[] bytes) {
+        SimpleDecoder dec = new SimpleDecoder(bytes);
+        byte[] header = dec.readBytes();
+        byte[] transactions = dec.readBytes();
+        byte[] results = dec.readBytes();
+        byte[] votes = dec.readBytes();
+
+        return Block.fromComponents(header, transactions, results, votes);
+    }
+
+    /**
+     * Get block size in bytes
+     *
+     * @return block size in bytes
+     */
+    public int size() {
+        return toBytes().length;
     }
 
     @Override

--- a/src/main/java/org/semux/core/BlockchainImpl.java
+++ b/src/main/java/org/semux/core/BlockchainImpl.java
@@ -246,7 +246,7 @@ public class BlockchainImpl implements Blockchain {
         byte[] results = blockDB.get(Bytes.merge(TYPE_BLOCK_RESULTS, Bytes.of(number)));
         byte[] votes = blockDB.get(Bytes.merge(TYPE_BLOCK_VOTES, Bytes.of(number)));
 
-        return (header == null) ? null : Block.fromBytes(header, transactions, results, votes);
+        return (header == null) ? null : Block.fromComponents(header, transactions, results, votes);
     }
 
     @Override
@@ -356,10 +356,10 @@ public class BlockchainImpl implements Blockchain {
         }
 
         // [1] update block
-        blockDB.put(Bytes.merge(TYPE_BLOCK_HEADER, Bytes.of(number)), block.toBytesHeader());
-        blockDB.put(Bytes.merge(TYPE_BLOCK_TRANSACTIONS, Bytes.of(number)), block.toBytesTransactions());
-        blockDB.put(Bytes.merge(TYPE_BLOCK_RESULTS, Bytes.of(number)), block.toBytesResults());
-        blockDB.put(Bytes.merge(TYPE_BLOCK_VOTES, Bytes.of(number)), block.toBytesVotes());
+        blockDB.put(Bytes.merge(TYPE_BLOCK_HEADER, Bytes.of(number)), block.getEncodedHeader());
+        blockDB.put(Bytes.merge(TYPE_BLOCK_TRANSACTIONS, Bytes.of(number)), block.getEncodedTransactions());
+        blockDB.put(Bytes.merge(TYPE_BLOCK_RESULTS, Bytes.of(number)), block.getEncodedResults());
+        blockDB.put(Bytes.merge(TYPE_BLOCK_VOTES, Bytes.of(number)), block.getEncodedVotes());
 
         indexDB.put(Bytes.merge(TYPE_BLOCK_HASH, hash), Bytes.of(number));
 

--- a/src/main/java/org/semux/core/Transaction.java
+++ b/src/main/java/org/semux/core/Transaction.java
@@ -154,7 +154,7 @@ public class Transaction {
 
     /**
      * Returns the transaction network id.
-     * 
+     *
      * @return
      */
     public byte getNetworkId() {
@@ -255,6 +255,7 @@ public class Transaction {
      */
     public static Transaction fromEncoded(byte[] encoded) {
         SimpleDecoder decoder = new SimpleDecoder(encoded);
+
         byte networkId = decoder.readByte();
         byte type = decoder.readByte();
         byte[] to = decoder.readBytes();
@@ -263,15 +264,8 @@ public class Transaction {
         long nonce = decoder.readLong();
         long timestamp = decoder.readLong();
         byte[] data = decoder.readBytes();
-        return new Transaction(
-                Network.of(networkId),
-                TransactionType.of(type),
-                to,
-                value,
-                fee,
-                nonce,
-                timestamp,
-                data);
+
+        return new Transaction(Network.of(networkId), TransactionType.of(type), to, value, fee, nonce, timestamp, data);
     }
 
     /**

--- a/src/main/java/org/semux/net/SemuxMessageHandler.java
+++ b/src/main/java/org/semux/net/SemuxMessageHandler.java
@@ -52,7 +52,7 @@ public class SemuxMessageHandler extends MessageToMessageCodec<Frame, Message> {
 
     @Override
     protected void encode(ChannelHandlerContext ctx, Message msg, List<Object> out) throws Exception {
-        byte[] data = msg.getEncoded();
+        byte[] data = msg.getBody();
         byte[] dataCompressed = data;
 
         switch (COMPRESS_TYPE) {

--- a/src/main/java/org/semux/net/msg/Message.java
+++ b/src/main/java/org/semux/net/msg/Message.java
@@ -14,7 +14,7 @@ import org.semux.util.Bytes;
  */
 public abstract class Message {
     /**
-     * message code.
+     * Message code.
      */
     protected final MessageCode code;
 
@@ -24,9 +24,9 @@ public abstract class Message {
     protected final Class<?> responseMessageClass;
 
     /**
-     * encoded data.
+     * Message body.
      */
-    protected byte[] encoded;
+    protected byte[] body;
 
     /**
      * Create a message instance.
@@ -37,16 +37,16 @@ public abstract class Message {
     public Message(MessageCode code, Class<?> responseMessageClass) {
         this.code = code;
         this.responseMessageClass = responseMessageClass;
-        this.encoded = Bytes.EMPTY_BYTES;
+        this.body = Bytes.EMPTY_BYTES;
     }
 
     /**
-     * Get the encoded byte array of this message
+     * Get the body of this message
      * 
      * @return
      */
-    public byte[] getEncoded() {
-        return encoded;
+    public byte[] getBody() {
+        return body;
     }
 
     /**

--- a/src/main/java/org/semux/net/msg/MessageFactory.java
+++ b/src/main/java/org/semux/net/msg/MessageFactory.java
@@ -38,13 +38,13 @@ public class MessageFactory {
      *
      * @param code
      *            The message code
-     * @param encoded
-     *            The message encoded
+     * @param body
+     *            The message body
      * @return The decoded message, or NULL if the message type is not unknown
      * @throws MessageException
      *             when the encoding is illegal
      */
-    public Message create(byte code, byte[] encoded) throws MessageException {
+    public Message create(byte code, byte[] body) throws MessageException {
 
         MessageCode c = MessageCode.of(code);
         if (c == null) {
@@ -55,45 +55,45 @@ public class MessageFactory {
         try {
             switch (c) {
             case DISCONNECT:
-                return new DisconnectMessage(encoded);
+                return new DisconnectMessage(body);
             case HELLO:
-                return new org.semux.net.msg.p2p.handshake.v1.HelloMessage(encoded);
+                return new org.semux.net.msg.p2p.handshake.v1.HelloMessage(body);
             case WORLD:
-                return new org.semux.net.msg.p2p.handshake.v1.WorldMessage(encoded);
+                return new org.semux.net.msg.p2p.handshake.v1.WorldMessage(body);
             case PING:
-                return new PingMessage(encoded);
+                return new PingMessage(body);
             case PONG:
-                return new PongMessage(encoded);
+                return new PongMessage(body);
             case GET_NODES:
-                return new GetNodesMessage(encoded);
+                return new GetNodesMessage(body);
             case NODES:
-                return new NodesMessage(encoded);
+                return new NodesMessage(body);
             case TRANSACTION:
-                return new TransactionMessage(encoded);
+                return new TransactionMessage(body);
             case HANDSHAKE_INIT:
-                return new InitMessage(encoded);
+                return new InitMessage(body);
             case HANDSHAKE_HELLO:
-                return new HelloMessage(encoded);
+                return new HelloMessage(body);
             case HANDSHAKE_WORLD:
-                return new WorldMessage(encoded);
+                return new WorldMessage(body);
 
             case GET_BLOCK:
-                return new GetBlockMessage(encoded);
+                return new GetBlockMessage(body);
             case BLOCK:
-                return new BlockMessage(encoded);
+                return new BlockMessage(body);
             case GET_BLOCK_HEADER:
-                return new GetBlockHeaderMessage(encoded);
+                return new GetBlockHeaderMessage(body);
             case BLOCK_HEADER:
-                return new BlockHeaderMessage(encoded);
+                return new BlockHeaderMessage(body);
 
             case BFT_NEW_HEIGHT:
-                return new NewHeightMessage(encoded);
+                return new NewHeightMessage(body);
             case BFT_NEW_VIEW:
-                return new NewViewMessage(encoded);
+                return new NewViewMessage(body);
             case BFT_PROPOSAL:
-                return new ProposalMessage(encoded);
+                return new ProposalMessage(body);
             case BFT_VOTE:
-                return new VoteMessage(encoded);
+                return new VoteMessage(body);
 
             default:
                 throw new UnreachableException();

--- a/src/main/java/org/semux/net/msg/consensus/BlockHeaderMessage.java
+++ b/src/main/java/org/semux/net/msg/consensus/BlockHeaderMessage.java
@@ -29,10 +29,10 @@ public class BlockHeaderMessage extends Message {
     public BlockHeaderMessage(byte[] encoded) {
         super(MessageCode.BLOCK_HEADER, null);
 
-        this.encoded = encoded;
-
         SimpleDecoder dec = new SimpleDecoder(encoded);
         this.header = BlockHeader.fromBytes(dec.readBytes());
+
+        this.encoded = encoded;
     }
 
     public BlockHeader getHeader() {

--- a/src/main/java/org/semux/net/msg/consensus/BlockHeaderMessage.java
+++ b/src/main/java/org/semux/net/msg/consensus/BlockHeaderMessage.java
@@ -21,16 +21,13 @@ public class BlockHeaderMessage extends Message {
 
         this.header = header;
 
-        SimpleEncoder enc = new SimpleEncoder();
-        enc.writeBytes(header.toBytes());
-        this.body = enc.toBytes();
+        this.body = header.toBytes();
     }
 
     public BlockHeaderMessage(byte[] body) {
         super(MessageCode.BLOCK_HEADER, null);
 
-        SimpleDecoder dec = new SimpleDecoder(body);
-        this.header = BlockHeader.fromBytes(dec.readBytes());
+        this.header = BlockHeader.fromBytes(body);
 
         this.body = body;
     }

--- a/src/main/java/org/semux/net/msg/consensus/BlockHeaderMessage.java
+++ b/src/main/java/org/semux/net/msg/consensus/BlockHeaderMessage.java
@@ -23,16 +23,16 @@ public class BlockHeaderMessage extends Message {
 
         SimpleEncoder enc = new SimpleEncoder();
         enc.writeBytes(header.toBytes());
-        this.encoded = enc.toBytes();
+        this.body = enc.toBytes();
     }
 
-    public BlockHeaderMessage(byte[] encoded) {
+    public BlockHeaderMessage(byte[] body) {
         super(MessageCode.BLOCK_HEADER, null);
 
-        SimpleDecoder dec = new SimpleDecoder(encoded);
+        SimpleDecoder dec = new SimpleDecoder(body);
         this.header = BlockHeader.fromBytes(dec.readBytes());
 
-        this.encoded = encoded;
+        this.body = body;
     }
 
     public BlockHeader getHeader() {

--- a/src/main/java/org/semux/net/msg/consensus/BlockMessage.java
+++ b/src/main/java/org/semux/net/msg/consensus/BlockMessage.java
@@ -32,15 +32,14 @@ public class BlockMessage extends Message {
     public BlockMessage(byte[] encoded) {
         super(MessageCode.BLOCK, null);
 
-        this.encoded = encoded;
-
         SimpleDecoder dec = new SimpleDecoder(encoded);
         byte[] header = dec.readBytes();
         byte[] transactions = dec.readBytes();
         byte[] results = dec.readBytes();
         byte[] votes = dec.readBytes();
-
         this.block = Block.fromBytes(header, transactions, results, votes);
+
+        this.encoded = encoded;
     }
 
     public Block getBlock() {

--- a/src/main/java/org/semux/net/msg/consensus/BlockMessage.java
+++ b/src/main/java/org/semux/net/msg/consensus/BlockMessage.java
@@ -26,20 +26,20 @@ public class BlockMessage extends Message {
         enc.writeBytes(block.toBytesTransactions());
         enc.writeBytes(block.toBytesResults());
         enc.writeBytes(block.toBytesVotes());
-        this.encoded = enc.toBytes();
+        this.body = enc.toBytes();
     }
 
-    public BlockMessage(byte[] encoded) {
+    public BlockMessage(byte[] body) {
         super(MessageCode.BLOCK, null);
 
-        SimpleDecoder dec = new SimpleDecoder(encoded);
+        SimpleDecoder dec = new SimpleDecoder(body);
         byte[] header = dec.readBytes();
         byte[] transactions = dec.readBytes();
         byte[] results = dec.readBytes();
         byte[] votes = dec.readBytes();
         this.block = Block.fromBytes(header, transactions, results, votes);
 
-        this.encoded = encoded;
+        this.body = body;
     }
 
     public Block getBlock() {

--- a/src/main/java/org/semux/net/msg/consensus/BlockMessage.java
+++ b/src/main/java/org/semux/net/msg/consensus/BlockMessage.java
@@ -21,23 +21,13 @@ public class BlockMessage extends Message {
 
         this.block = block;
 
-        SimpleEncoder enc = new SimpleEncoder();
-        enc.writeBytes(block.toBytesHeader());
-        enc.writeBytes(block.toBytesTransactions());
-        enc.writeBytes(block.toBytesResults());
-        enc.writeBytes(block.toBytesVotes());
-        this.body = enc.toBytes();
+        this.body = block.toBytes();
     }
 
     public BlockMessage(byte[] body) {
         super(MessageCode.BLOCK, null);
 
-        SimpleDecoder dec = new SimpleDecoder(body);
-        byte[] header = dec.readBytes();
-        byte[] transactions = dec.readBytes();
-        byte[] results = dec.readBytes();
-        byte[] votes = dec.readBytes();
-        this.block = Block.fromBytes(header, transactions, results, votes);
+        this.block = Block.fromBytes(body);
 
         this.body = body;
     }

--- a/src/main/java/org/semux/net/msg/consensus/GetBlockHeaderMessage.java
+++ b/src/main/java/org/semux/net/msg/consensus/GetBlockHeaderMessage.java
@@ -12,6 +12,7 @@ import org.semux.util.SimpleDecoder;
 import org.semux.util.SimpleEncoder;
 
 public class GetBlockHeaderMessage extends Message {
+
     private final long number;
 
     public GetBlockHeaderMessage(long number) {
@@ -27,10 +28,10 @@ public class GetBlockHeaderMessage extends Message {
     public GetBlockHeaderMessage(byte[] encoded) {
         super(MessageCode.GET_BLOCK_HEADER, BlockHeaderMessage.class);
 
-        this.encoded = encoded;
-
         SimpleDecoder dec = new SimpleDecoder(encoded);
         this.number = dec.readLong();
+
+        this.encoded = encoded;
     }
 
     public long getNumber() {

--- a/src/main/java/org/semux/net/msg/consensus/GetBlockHeaderMessage.java
+++ b/src/main/java/org/semux/net/msg/consensus/GetBlockHeaderMessage.java
@@ -22,16 +22,16 @@ public class GetBlockHeaderMessage extends Message {
 
         SimpleEncoder enc = new SimpleEncoder();
         enc.writeLong(number);
-        this.encoded = enc.toBytes();
+        this.body = enc.toBytes();
     }
 
-    public GetBlockHeaderMessage(byte[] encoded) {
+    public GetBlockHeaderMessage(byte[] body) {
         super(MessageCode.GET_BLOCK_HEADER, BlockHeaderMessage.class);
 
-        SimpleDecoder dec = new SimpleDecoder(encoded);
+        SimpleDecoder dec = new SimpleDecoder(body);
         this.number = dec.readLong();
 
-        this.encoded = encoded;
+        this.body = body;
     }
 
     public long getNumber() {

--- a/src/main/java/org/semux/net/msg/consensus/GetBlockMessage.java
+++ b/src/main/java/org/semux/net/msg/consensus/GetBlockMessage.java
@@ -21,16 +21,16 @@ public class GetBlockMessage extends Message {
 
         SimpleEncoder enc = new SimpleEncoder();
         enc.writeLong(number);
-        this.encoded = enc.toBytes();
+        this.body = enc.toBytes();
     }
 
-    public GetBlockMessage(byte[] encoded) {
+    public GetBlockMessage(byte[] body) {
         super(MessageCode.GET_BLOCK, BlockMessage.class);
 
-        SimpleDecoder dec = new SimpleDecoder(encoded);
+        SimpleDecoder dec = new SimpleDecoder(body);
         this.number = dec.readLong();
 
-        this.encoded = encoded;
+        this.body = body;
     }
 
     public long getNumber() {

--- a/src/main/java/org/semux/net/msg/consensus/GetBlockMessage.java
+++ b/src/main/java/org/semux/net/msg/consensus/GetBlockMessage.java
@@ -8,21 +8,29 @@ package org.semux.net.msg.consensus;
 
 import org.semux.net.msg.Message;
 import org.semux.net.msg.MessageCode;
-import org.semux.util.Bytes;
+import org.semux.util.SimpleDecoder;
+import org.semux.util.SimpleEncoder;
 
 public class GetBlockMessage extends Message {
+
     private final long number;
 
     public GetBlockMessage(long number) {
         super(MessageCode.GET_BLOCK, BlockMessage.class);
         this.number = number;
-        this.encoded = Bytes.of(number);
+
+        SimpleEncoder enc = new SimpleEncoder();
+        enc.writeLong(number);
+        this.encoded = enc.toBytes();
     }
 
     public GetBlockMessage(byte[] encoded) {
         super(MessageCode.GET_BLOCK, BlockMessage.class);
+
+        SimpleDecoder dec = new SimpleDecoder(encoded);
+        this.number = dec.readLong();
+
         this.encoded = encoded;
-        this.number = Bytes.toLong(encoded);
     }
 
     public long getNumber() {

--- a/src/main/java/org/semux/net/msg/consensus/NewHeightMessage.java
+++ b/src/main/java/org/semux/net/msg/consensus/NewHeightMessage.java
@@ -8,7 +8,8 @@ package org.semux.net.msg.consensus;
 
 import org.semux.net.msg.Message;
 import org.semux.net.msg.MessageCode;
-import org.semux.util.Bytes;
+import org.semux.util.SimpleDecoder;
+import org.semux.util.SimpleEncoder;
 
 public class NewHeightMessage extends Message {
 
@@ -18,14 +19,18 @@ public class NewHeightMessage extends Message {
         super(MessageCode.BFT_NEW_HEIGHT, null);
         this.height = height;
 
-        this.encoded = Bytes.of(height);
+        SimpleEncoder enc = new SimpleEncoder();
+        enc.writeLong(height);
+        this.encoded = enc.toBytes();
     }
 
     public NewHeightMessage(byte[] encoded) {
         super(MessageCode.BFT_NEW_HEIGHT, null);
-        this.encoded = encoded;
 
-        this.height = Bytes.toLong(encoded);
+        SimpleDecoder dec = new SimpleDecoder(encoded);
+        this.height = dec.readLong();
+
+        this.encoded = encoded;
     }
 
     public long getHeight() {

--- a/src/main/java/org/semux/net/msg/consensus/NewHeightMessage.java
+++ b/src/main/java/org/semux/net/msg/consensus/NewHeightMessage.java
@@ -21,16 +21,16 @@ public class NewHeightMessage extends Message {
 
         SimpleEncoder enc = new SimpleEncoder();
         enc.writeLong(height);
-        this.encoded = enc.toBytes();
+        this.body = enc.toBytes();
     }
 
-    public NewHeightMessage(byte[] encoded) {
+    public NewHeightMessage(byte[] body) {
         super(MessageCode.BFT_NEW_HEIGHT, null);
 
-        SimpleDecoder dec = new SimpleDecoder(encoded);
+        SimpleDecoder dec = new SimpleDecoder(body);
         this.height = dec.readLong();
 
-        this.encoded = encoded;
+        this.body = body;
     }
 
     public long getHeight() {

--- a/src/main/java/org/semux/net/msg/consensus/NewViewMessage.java
+++ b/src/main/java/org/semux/net/msg/consensus/NewViewMessage.java
@@ -20,15 +20,15 @@ public class NewViewMessage extends Message {
         this.proof = proof;
 
         // FIXME: consider wrapping by simple codec
-        this.encoded = proof.toBytes();
+        this.body = proof.toBytes();
     }
 
-    public NewViewMessage(byte[] encoded) {
+    public NewViewMessage(byte[] body) {
         super(MessageCode.BFT_NEW_VIEW, null);
 
-        this.proof = Proof.fromBytes(encoded);
+        this.proof = Proof.fromBytes(body);
 
-        this.encoded = encoded;
+        this.body = body;
     }
 
     public Proof getProof() {

--- a/src/main/java/org/semux/net/msg/consensus/NewViewMessage.java
+++ b/src/main/java/org/semux/net/msg/consensus/NewViewMessage.java
@@ -12,19 +12,23 @@ import org.semux.net.msg.MessageCode;
 
 public class NewViewMessage extends Message {
 
-    private Proof proof;
+    private final Proof proof;
 
     public NewViewMessage(Proof proof) {
         super(MessageCode.BFT_NEW_VIEW, null);
 
+        this.proof = proof;
+
+        // FIXME: consider wrapping by simple codec
         this.encoded = proof.toBytes();
     }
 
     public NewViewMessage(byte[] encoded) {
         super(MessageCode.BFT_NEW_VIEW, null);
-        this.encoded = encoded;
 
         this.proof = Proof.fromBytes(encoded);
+
+        this.encoded = encoded;
     }
 
     public Proof getProof() {

--- a/src/main/java/org/semux/net/msg/consensus/ProposalMessage.java
+++ b/src/main/java/org/semux/net/msg/consensus/ProposalMessage.java
@@ -20,15 +20,15 @@ public class ProposalMessage extends Message {
         this.proposal = proposal;
 
         // FIXME: consider wrapping by simple codec
-        this.encoded = proposal.toBytes();
+        this.body = proposal.toBytes();
     }
 
-    public ProposalMessage(byte[] encoded) {
+    public ProposalMessage(byte[] body) {
         super(MessageCode.BFT_PROPOSAL, null);
 
-        this.proposal = Proposal.fromBytes(encoded);
+        this.proposal = Proposal.fromBytes(body);
 
-        this.encoded = encoded;
+        this.body = body;
     }
 
     public Proposal getProposal() {

--- a/src/main/java/org/semux/net/msg/consensus/ProposalMessage.java
+++ b/src/main/java/org/semux/net/msg/consensus/ProposalMessage.java
@@ -16,16 +16,19 @@ public class ProposalMessage extends Message {
 
     public ProposalMessage(Proposal proposal) {
         super(MessageCode.BFT_PROPOSAL, null);
+
         this.proposal = proposal;
 
+        // FIXME: consider wrapping by simple codec
         this.encoded = proposal.toBytes();
     }
 
     public ProposalMessage(byte[] encoded) {
         super(MessageCode.BFT_PROPOSAL, null);
-        this.encoded = encoded;
 
         this.proposal = Proposal.fromBytes(encoded);
+
+        this.encoded = encoded;
     }
 
     public Proposal getProposal() {

--- a/src/main/java/org/semux/net/msg/consensus/VoteMessage.java
+++ b/src/main/java/org/semux/net/msg/consensus/VoteMessage.java
@@ -20,15 +20,15 @@ public class VoteMessage extends Message {
         this.vote = vote;
 
         // FIXME: consider wrapping by simple codec
-        this.encoded = vote.toBytes();
+        this.body = vote.toBytes();
     }
 
-    public VoteMessage(byte[] encoded) {
+    public VoteMessage(byte[] body) {
         super(MessageCode.BFT_VOTE, null);
 
-        this.vote = Vote.fromBytes(encoded);
+        this.vote = Vote.fromBytes(body);
 
-        this.encoded = encoded;
+        this.body = body;
     }
 
     public Vote getVote() {

--- a/src/main/java/org/semux/net/msg/consensus/VoteMessage.java
+++ b/src/main/java/org/semux/net/msg/consensus/VoteMessage.java
@@ -16,16 +16,19 @@ public class VoteMessage extends Message {
 
     public VoteMessage(Vote vote) {
         super(MessageCode.BFT_VOTE, null);
+
         this.vote = vote;
 
+        // FIXME: consider wrapping by simple codec
         this.encoded = vote.toBytes();
     }
 
     public VoteMessage(byte[] encoded) {
         super(MessageCode.BFT_VOTE, null);
-        this.encoded = encoded;
 
         this.vote = Vote.fromBytes(encoded);
+
+        this.encoded = encoded;
     }
 
     public Vote getVote() {

--- a/src/main/java/org/semux/net/msg/p2p/DisconnectMessage.java
+++ b/src/main/java/org/semux/net/msg/p2p/DisconnectMessage.java
@@ -28,21 +28,21 @@ public class DisconnectMessage extends Message {
 
         SimpleEncoder enc = new SimpleEncoder();
         enc.writeByte(reason.toByte());
-        this.encoded = enc.toBytes();
+        this.body = enc.toBytes();
     }
 
     /**
      * Parse a DISCONNECT message from byte array.
      * 
-     * @param encoded
+     * @param body
      */
-    public DisconnectMessage(byte[] encoded) {
+    public DisconnectMessage(byte[] body) {
         super(MessageCode.DISCONNECT, null);
 
-        SimpleDecoder dec = new SimpleDecoder(encoded);
+        SimpleDecoder dec = new SimpleDecoder(body);
         this.reason = ReasonCode.of(dec.readByte());
 
-        this.encoded = encoded;
+        this.body = body;
     }
 
     public ReasonCode getReason() {

--- a/src/main/java/org/semux/net/msg/p2p/DisconnectMessage.java
+++ b/src/main/java/org/semux/net/msg/p2p/DisconnectMessage.java
@@ -9,7 +9,8 @@ package org.semux.net.msg.p2p;
 import org.semux.net.msg.Message;
 import org.semux.net.msg.MessageCode;
 import org.semux.net.msg.ReasonCode;
-import org.semux.util.Bytes;
+import org.semux.util.SimpleDecoder;
+import org.semux.util.SimpleEncoder;
 
 public class DisconnectMessage extends Message {
 
@@ -25,7 +26,9 @@ public class DisconnectMessage extends Message {
 
         this.reason = reason;
 
-        this.encoded = Bytes.of(reason.toByte());
+        SimpleEncoder enc = new SimpleEncoder();
+        enc.writeByte(reason.toByte());
+        this.encoded = enc.toBytes();
     }
 
     /**
@@ -36,9 +39,10 @@ public class DisconnectMessage extends Message {
     public DisconnectMessage(byte[] encoded) {
         super(MessageCode.DISCONNECT, null);
 
-        this.encoded = encoded;
+        SimpleDecoder dec = new SimpleDecoder(encoded);
+        this.reason = ReasonCode.of(dec.readByte());
 
-        this.reason = ReasonCode.of(Bytes.toByte(encoded));
+        this.encoded = encoded;
     }
 
     public ReasonCode getReason() {

--- a/src/main/java/org/semux/net/msg/p2p/GetNodesMessage.java
+++ b/src/main/java/org/semux/net/msg/p2p/GetNodesMessage.java
@@ -22,18 +22,18 @@ public class GetNodesMessage extends Message {
         super(MessageCode.GET_NODES, NodesMessage.class);
 
         SimpleEncoder enc = new SimpleEncoder();
-        this.encoded = enc.toBytes();
+        this.body = enc.toBytes();
     }
 
     /**
      * Parse a GET_NODES message from byte array.
      * 
-     * @param encoded
+     * @param body
      */
-    public GetNodesMessage(byte[] encoded) {
+    public GetNodesMessage(byte[] body) {
         super(MessageCode.GET_NODES, NodesMessage.class);
 
-        this.encoded = encoded;
+        this.body = body;
     }
 
     @Override

--- a/src/main/java/org/semux/net/msg/p2p/GetNodesMessage.java
+++ b/src/main/java/org/semux/net/msg/p2p/GetNodesMessage.java
@@ -8,7 +8,7 @@ package org.semux.net.msg.p2p;
 
 import org.semux.net.msg.Message;
 import org.semux.net.msg.MessageCode;
-import org.semux.util.Bytes;
+import org.semux.util.SimpleEncoder;
 
 // NOTE: GetNodesMessage is encoded into a single empty frame.
 
@@ -21,7 +21,8 @@ public class GetNodesMessage extends Message {
     public GetNodesMessage() {
         super(MessageCode.GET_NODES, NodesMessage.class);
 
-        this.encoded = Bytes.EMPTY_BYTES;
+        SimpleEncoder enc = new SimpleEncoder();
+        this.encoded = enc.toBytes();
     }
 
     /**

--- a/src/main/java/org/semux/net/msg/p2p/NodesMessage.java
+++ b/src/main/java/org/semux/net/msg/p2p/NodesMessage.java
@@ -48,16 +48,15 @@ public class NodesMessage extends Message {
     public NodesMessage(byte[] encoded) {
         super(MessageCode.NODES, null);
 
-        this.encoded = encoded;
-
-        nodes = new ArrayList<>();
+        this.nodes = new ArrayList<>();
         SimpleDecoder dec = new SimpleDecoder(encoded);
-        int n = dec.readInt();
-        for (int i = 0; i < n; i++) {
+        for (int i = 0, size = dec.readInt(); i < size; i++) {
             String host = dec.readString();
             int port = dec.readInt();
             nodes.add(new Node(host, port));
         }
+
+        this.encoded = encoded;
     }
 
     public boolean validate() {

--- a/src/main/java/org/semux/net/msg/p2p/NodesMessage.java
+++ b/src/main/java/org/semux/net/msg/p2p/NodesMessage.java
@@ -37,26 +37,26 @@ public class NodesMessage extends Message {
             enc.writeString(n.getIp());
             enc.writeInt(n.getPort());
         }
-        this.encoded = enc.toBytes();
+        this.body = enc.toBytes();
     }
 
     /**
      * Parse a NODES message from byte array.
      * 
-     * @param encoded
+     * @param body
      */
-    public NodesMessage(byte[] encoded) {
+    public NodesMessage(byte[] body) {
         super(MessageCode.NODES, null);
 
         this.nodes = new ArrayList<>();
-        SimpleDecoder dec = new SimpleDecoder(encoded);
+        SimpleDecoder dec = new SimpleDecoder(body);
         for (int i = 0, size = dec.readInt(); i < size; i++) {
             String host = dec.readString();
             int port = dec.readInt();
             nodes.add(new Node(host, port));
         }
 
-        this.encoded = encoded;
+        this.body = body;
     }
 
     public boolean validate() {

--- a/src/main/java/org/semux/net/msg/p2p/PingMessage.java
+++ b/src/main/java/org/semux/net/msg/p2p/PingMessage.java
@@ -27,21 +27,21 @@ public class PingMessage extends Message {
 
         SimpleEncoder enc = new SimpleEncoder();
         enc.writeLong(timestamp);
-        this.encoded = enc.toBytes();
+        this.body = enc.toBytes();
     }
 
     /**
      * Parse a PING message from byte array.
      * 
-     * @param encoded
+     * @param body
      */
-    public PingMessage(byte[] encoded) {
+    public PingMessage(byte[] body) {
         super(MessageCode.PING, PongMessage.class);
 
-        SimpleDecoder dec = new SimpleDecoder(encoded);
+        SimpleDecoder dec = new SimpleDecoder(body);
         this.timestamp = dec.readLong();
 
-        this.encoded = encoded;
+        this.body = body;
     }
 
     @Override

--- a/src/main/java/org/semux/net/msg/p2p/PongMessage.java
+++ b/src/main/java/org/semux/net/msg/p2p/PongMessage.java
@@ -26,21 +26,21 @@ public class PongMessage extends Message {
 
         SimpleEncoder enc = new SimpleEncoder();
         enc.writeLong(timestamp);
-        this.encoded = enc.toBytes();
+        this.body = enc.toBytes();
     }
 
     /**
      * Parse a PONG message from byte array.
      * 
-     * @param encoded
+     * @param body
      */
-    public PongMessage(byte[] encoded) {
+    public PongMessage(byte[] body) {
         super(MessageCode.PONG, null);
 
-        SimpleDecoder dec = new SimpleDecoder(encoded);
+        SimpleDecoder dec = new SimpleDecoder(body);
         this.timestamp = dec.readLong();
 
-        this.encoded = encoded;
+        this.body = body;
     }
 
     @Override

--- a/src/main/java/org/semux/net/msg/p2p/TransactionMessage.java
+++ b/src/main/java/org/semux/net/msg/p2p/TransactionMessage.java
@@ -24,20 +24,20 @@ public class TransactionMessage extends Message {
         this.transaction = transaction;
 
         // FIXME: consider wrapping by simple codec
-        this.encoded = transaction.toBytes();
+        this.body = transaction.toBytes();
     }
 
     /**
      * Parse a TRANSACTION message from byte array.
      * 
-     * @param encoded
+     * @param body
      */
-    public TransactionMessage(byte[] encoded) {
+    public TransactionMessage(byte[] body) {
         super(MessageCode.TRANSACTION, null);
 
-        this.transaction = Transaction.fromBytes(encoded);
+        this.transaction = Transaction.fromBytes(body);
 
-        this.encoded = encoded;
+        this.body = body;
     }
 
     public Transaction getTransaction() {

--- a/src/main/java/org/semux/net/msg/p2p/TransactionMessage.java
+++ b/src/main/java/org/semux/net/msg/p2p/TransactionMessage.java
@@ -23,6 +23,7 @@ public class TransactionMessage extends Message {
 
         this.transaction = transaction;
 
+        // FIXME: consider wrapping by simple codec
         this.encoded = transaction.toBytes();
     }
 

--- a/src/main/java/org/semux/net/msg/p2p/handshake/v1/HelloMessage.java
+++ b/src/main/java/org/semux/net/msg/p2p/handshake/v1/HelloMessage.java
@@ -41,23 +41,23 @@ public class HelloMessage extends Message {
         this.signature = coinbase.sign(enc.toBytes());
         enc.writeBytes(signature.toBytes());
 
-        this.encoded = enc.toBytes();
+        this.body = enc.toBytes();
     }
 
     /**
      * Parse a HELLO message from byte array.
      *
-     * @param encoded
+     * @param body
      */
-    public HelloMessage(byte[] encoded) {
+    public HelloMessage(byte[] body) {
         super(MessageCode.HELLO, WorldMessage.class);
 
-        SimpleDecoder dec = new SimpleDecoder(encoded);
+        SimpleDecoder dec = new SimpleDecoder(body);
         this.peer = PeerCodec.fromBytes(dec.readBytes());
         this.timestamp = dec.readLong();
         this.signature = Signature.fromBytes(dec.readBytes());
 
-        this.encoded = encoded;
+        this.body = body;
     }
 
     /**

--- a/src/main/java/org/semux/net/msg/p2p/handshake/v1/WorldMessage.java
+++ b/src/main/java/org/semux/net/msg/p2p/handshake/v1/WorldMessage.java
@@ -41,23 +41,23 @@ public class WorldMessage extends Message {
         this.signature = coinbase.sign(enc.toBytes());
         enc.writeBytes(signature.toBytes());
 
-        this.encoded = enc.toBytes();
+        this.body = enc.toBytes();
     }
 
     /**
      * Parse a WORLD message from byte array.
      *
-     * @param encoded
+     * @param body
      */
-    public WorldMessage(byte[] encoded) {
+    public WorldMessage(byte[] body) {
         super(MessageCode.WORLD, null);
 
-        SimpleDecoder dec = new SimpleDecoder(encoded);
+        SimpleDecoder dec = new SimpleDecoder(body);
         this.peer = PeerCodec.fromBytes(dec.readBytes());
         this.timestamp = dec.readLong();
         this.signature = Signature.fromBytes(dec.readBytes());
 
-        this.encoded = encoded;
+        this.body = body;
     }
 
     /**

--- a/src/main/java/org/semux/net/msg/p2p/handshake/v2/HandshakeMessage.java
+++ b/src/main/java/org/semux/net/msg/p2p/handshake/v2/HandshakeMessage.java
@@ -58,14 +58,13 @@ public abstract class HandshakeMessage extends Message {
         this.signature = coinbase.sign(enc.toBytes());
         enc.writeBytes(signature.toBytes());
 
-        this.encoded = enc.toBytes();
+        this.body = enc.toBytes();
     }
 
-    public HandshakeMessage(MessageCode code, Class<?> responseMessageClass,
-            byte[] encoded) {
+    public HandshakeMessage(MessageCode code, Class<?> responseMessageClass, byte[] body) {
         super(code, responseMessageClass);
 
-        SimpleDecoder dec = new SimpleDecoder(encoded);
+        SimpleDecoder dec = new SimpleDecoder(body);
         this.network = Network.of(dec.readByte());
         this.networkVersion = dec.readShort();
         this.peerId = dec.readString();
@@ -81,7 +80,7 @@ public abstract class HandshakeMessage extends Message {
         this.timestamp = dec.readLong();
         this.signature = Key.Signature.fromBytes(dec.readBytes());
 
-        this.encoded = encoded;
+        this.body = body;
     }
 
     protected SimpleEncoder encodeBasicInfo() {

--- a/src/main/java/org/semux/net/msg/p2p/handshake/v2/InitMessage.java
+++ b/src/main/java/org/semux/net/msg/p2p/handshake/v2/InitMessage.java
@@ -16,8 +16,8 @@ public class InitMessage extends Message {
 
     public static final int SECRET_LENGTH = 32;
 
-    private byte[] secret;
-    private long timestamp;
+    private final byte[] secret;
+    private final long timestamp;
 
     public InitMessage(byte[] secret, long timestamp) {
         super(MessageCode.HANDSHAKE_INIT, null);

--- a/src/main/java/org/semux/net/msg/p2p/handshake/v2/InitMessage.java
+++ b/src/main/java/org/semux/net/msg/p2p/handshake/v2/InitMessage.java
@@ -29,17 +29,17 @@ public class InitMessage extends Message {
         enc.writeBytes(secret);
         enc.writeLong(timestamp);
 
-        this.encoded = enc.toBytes();
+        this.body = enc.toBytes();
     }
 
-    public InitMessage(byte[] encoded) {
+    public InitMessage(byte[] body) {
         super(MessageCode.HANDSHAKE_INIT, null);
 
-        SimpleDecoder dec = new SimpleDecoder(encoded);
+        SimpleDecoder dec = new SimpleDecoder(body);
         this.secret = dec.readBytes();
         this.timestamp = dec.readLong();
 
-        this.encoded = encoded;
+        this.body = body;
     }
 
     public boolean validate() {

--- a/src/main/java/org/semux/util/SimpleDecoder.java
+++ b/src/main/java/org/semux/util/SimpleDecoder.java
@@ -68,6 +68,12 @@ public class SimpleDecoder {
         return NANO_SEM.of(readLong());
     }
 
+    /**
+     * Decode a byte array.
+     *
+     * @param vlq
+     *            should always be true unless we're providing pre-mainnet support.
+     */
     public byte[] readBytes(boolean vlq) {
         int len = vlq ? readSize() : readInt();
 

--- a/src/main/java/org/semux/util/SimpleEncoder.java
+++ b/src/main/java/org/semux/util/SimpleEncoder.java
@@ -60,6 +60,14 @@ public class SimpleEncoder {
         writeLong(a.getNano());
     }
 
+    /**
+     * Encode a byte array.
+     *
+     * @param bytes
+     *            the byte array to encode
+     * @param vlq
+     *            should always be true unless we're providing pre-mainnet support.
+     */
     public void writeBytes(byte[] bytes, boolean vlq) {
         if (vlq) {
             writeSize(bytes.length);

--- a/src/test/java/org/semux/bench/BlockchainPerformance.java
+++ b/src/test/java/org/semux/bench/BlockchainPerformance.java
@@ -89,10 +89,10 @@ public class BlockchainPerformance {
 
         long t2 = System.nanoTime();
         logger.info("block # of txs: {}", block.getTransactions().size());
-        logger.info("block header size: {} B", block.toBytesHeader().length);
-        logger.info("block transaction size: {} KB", block.toBytesTransactions().length / 1024);
-        logger.info("block results size: {} KB", block.toBytesResults().length / 1024);
-        logger.info("block votes size: {} KB", block.toBytesVotes().length / 1024);
+        logger.info("block header size: {} B", block.getEncodedHeader().length);
+        logger.info("block transaction size: {} KB", block.getEncodedTransactions().length / 1024);
+        logger.info("block results size: {} KB", block.getEncodedResults().length / 1024);
+        logger.info("block votes size: {} KB", block.getEncodedVotes().length / 1024);
         logger.info("block total size: {} KB", block.size() / 1024);
         logger.info("Perf_block_creation: {} ms", (t2 - t1) / 1_000_000);
         return block;

--- a/src/test/java/org/semux/bench/CompressPerformance.java
+++ b/src/test/java/org/semux/bench/CompressPerformance.java
@@ -45,9 +45,9 @@ public class CompressPerformance {
 
                 blocks++;
                 transactions += b.getTransactions().size();
-                size += m.getEncoded().length;
+                size += m.getBody().length;
                 long t1 = System.nanoTime();
-                sizeCompressed += Snappy.compress(m.getEncoded()).length;
+                sizeCompressed += Snappy.compress(m.getBody()).length;
                 long t2 = System.nanoTime();
                 time += t2 - t1;
             }

--- a/src/test/java/org/semux/consensus/VoteTest.java
+++ b/src/test/java/org/semux/consensus/VoteTest.java
@@ -91,8 +91,9 @@ public class VoteTest {
 
         block.setView(view);
         block.setVotes(votes);
-        block = Block.fromBytes(block.toBytesHeader(), block.toBytesTransactions(), block.toBytesResults(),
-                block.toBytesVotes());
+        block = Block.fromComponents(block.getEncodedHeader(), block.getEncodedTransactions(),
+                block.getEncodedResults(),
+                block.getEncodedVotes());
 
         for (Key.Signature sig : block.getVotes()) {
             ByteArray address = ByteArray.of(Hash.h160(sig.getPublicKey()));

--- a/src/test/java/org/semux/core/BlockTest.java
+++ b/src/test/java/org/semux/core/BlockTest.java
@@ -76,8 +76,9 @@ public class BlockTest {
         Block block = new Block(header, transactions, results, view, votes);
         hash = block.getHash();
 
-        testFields(Block.fromBytes(block.toBytesHeader(), block.toBytesTransactions(), block.toBytesResults(),
-                block.toBytesVotes()));
+        testFields(Block.fromComponents(block.getEncodedHeader(), block.getEncodedTransactions(),
+                block.getEncodedResults(),
+                block.getEncodedVotes()));
     }
 
     private void testFields(Block block) {
@@ -104,7 +105,7 @@ public class BlockTest {
         assertEquals(1, indexes.size());
 
         Pair<Integer, Integer> index = indexes.get(0);
-        SimpleDecoder dec = new SimpleDecoder(block.toBytesTransactions(), index.getLeft());
+        SimpleDecoder dec = new SimpleDecoder(block.getEncodedTransactions(), index.getLeft());
         Transaction tx2 = Transaction.fromBytes(dec.readBytes());
         assertArrayEquals(tx.getHash(), tx2.getHash());
     }

--- a/src/test/java/org/semux/core/BlockchainImplTest.java
+++ b/src/test/java/org/semux/core/BlockchainImplTest.java
@@ -221,8 +221,9 @@ public class BlockchainImplTest {
     public void testSerialization() {
         Block block1 = createBlock(1);
 
-        Block block2 = Block.fromBytes(block1.toBytesHeader(), block1.toBytesTransactions(), block1.toBytesResults(),
-                block1.toBytesVotes());
+        Block block2 = Block.fromComponents(block1.getEncodedHeader(), block1.getEncodedTransactions(),
+                block1.getEncodedResults(),
+                block1.getEncodedVotes());
         assertArrayEquals(block1.getHash(), block2.getHash());
         assertArrayEquals(block1.getCoinbase(), block2.getCoinbase());
         assertArrayEquals(block1.getParentHash(), block2.getParentHash());

--- a/src/test/java/org/semux/net/msg/consensus/BlockHeaderMessageTest.java
+++ b/src/test/java/org/semux/net/msg/consensus/BlockHeaderMessageTest.java
@@ -38,7 +38,7 @@ public class BlockHeaderMessageTest {
         assertThat(m.getCode()).isEqualTo(MessageCode.BLOCK_HEADER);
         assertThat(m.getResponseMessageClass()).isNull();
 
-        BlockHeaderMessage m2 = new BlockHeaderMessage(m.getEncoded());
+        BlockHeaderMessage m2 = new BlockHeaderMessage(m.getBody());
         assertThat(m2.getCode()).isEqualTo(MessageCode.BLOCK_HEADER);
         assertThat(m2.getResponseMessageClass()).isNull();
         assertThat(m2.getHeader()).isEqualToComparingFieldByField(header);

--- a/src/test/java/org/semux/net/msg/consensus/GetBlockHeaderMessageTest.java
+++ b/src/test/java/org/semux/net/msg/consensus/GetBlockHeaderMessageTest.java
@@ -21,7 +21,7 @@ public class GetBlockHeaderMessageTest {
         assertThat(m.getCode()).isEqualTo(MessageCode.GET_BLOCK_HEADER);
         assertThat(m.getResponseMessageClass()).isEqualTo(BlockHeaderMessage.class);
 
-        GetBlockHeaderMessage m2 = new GetBlockHeaderMessage(m.getEncoded());
+        GetBlockHeaderMessage m2 = new GetBlockHeaderMessage(m.getBody());
         assertThat(m2.getCode()).isEqualTo(MessageCode.GET_BLOCK_HEADER);
         assertThat(m2.getResponseMessageClass()).isEqualTo(BlockHeaderMessage.class);
         assertThat(m2.getNumber()).isEqualTo(number);

--- a/src/test/java/org/semux/net/msg/consensus/NewHeightMessageTest.java
+++ b/src/test/java/org/semux/net/msg/consensus/NewHeightMessageTest.java
@@ -16,7 +16,7 @@ public class NewHeightMessageTest {
         int height = 1;
 
         NewHeightMessage msg = new NewHeightMessage(height);
-        NewHeightMessage msg2 = new NewHeightMessage(msg.getEncoded());
+        NewHeightMessage msg2 = new NewHeightMessage(msg.getBody());
         assertEquals(height, msg2.getHeight());
     }
 }

--- a/src/test/java/org/semux/net/msg/consensus/NewViewMessageTest.java
+++ b/src/test/java/org/semux/net/msg/consensus/NewViewMessageTest.java
@@ -22,7 +22,7 @@ public class NewViewMessageTest {
         Proof proof = new Proof(height, view, Collections.emptyList());
 
         NewViewMessage msg = new NewViewMessage(proof);
-        NewViewMessage msg2 = new NewViewMessage(msg.getEncoded());
+        NewViewMessage msg2 = new NewViewMessage(msg.getBody());
         assertEquals(height, msg2.getHeight());
         assertEquals(view, msg2.getView());
         assertTrue(msg2.getProof().getVotes().isEmpty());

--- a/src/test/java/org/semux/net/msg/consensus/ProposalMessageTest.java
+++ b/src/test/java/org/semux/net/msg/consensus/ProposalMessageTest.java
@@ -41,7 +41,7 @@ public class ProposalMessageTest {
         proposal.sign(new Key());
 
         ProposalMessage msg = new ProposalMessage(proposal);
-        ProposalMessage msg2 = new ProposalMessage(msg.getEncoded());
+        ProposalMessage msg2 = new ProposalMessage(msg.getBody());
 
         assertThat(msg2.getProposal()).isEqualToComparingFieldByFieldRecursively(proposal);
     }

--- a/src/test/java/org/semux/net/msg/consensus/VoteMessageTest.java
+++ b/src/test/java/org/semux/net/msg/consensus/VoteMessageTest.java
@@ -27,7 +27,7 @@ public class VoteMessageTest {
         assertTrue(vote.validate());
 
         VoteMessage msg = new VoteMessage(vote);
-        VoteMessage msg2 = new VoteMessage(msg.getEncoded());
+        VoteMessage msg2 = new VoteMessage(msg.getBody());
         Vote vote2 = msg2.getVote();
         assertEquals(type, vote2.getType());
         assertEquals(height, vote2.getHeight());

--- a/src/test/java/org/semux/net/msg/p2p/NodesMessageTest.java
+++ b/src/test/java/org/semux/net/msg/p2p/NodesMessageTest.java
@@ -24,7 +24,7 @@ public class NodesMessageTest {
         List<Node> nodes = new ArrayList<>();
         nodes.add(new Node(new InetSocketAddress("127.0.0.1", 5160)));
         nodes.add(new Node(new InetSocketAddress("127.0.0.1", 5161)));
-        NodesMessage nodesMessage = new NodesMessage(new NodesMessage(nodes).getEncoded());
+        NodesMessage nodesMessage = new NodesMessage(new NodesMessage(nodes).getBody());
         assertArrayEquals(nodes.toArray(), nodesMessage.getNodes().toArray());
     }
 

--- a/src/test/java/org/semux/net/msg/p2p/TransactionMessageTest.java
+++ b/src/test/java/org/semux/net/msg/p2p/TransactionMessageTest.java
@@ -35,7 +35,7 @@ public class TransactionMessageTest {
         tx.sign(new Key());
 
         TransactionMessage msg = new TransactionMessage(tx);
-        TransactionMessage msg2 = new TransactionMessage(msg.getEncoded());
+        TransactionMessage msg2 = new TransactionMessage(msg.getBody());
         assertThat(msg2.getTransaction().getHash(), equalTo(tx.getHash()));
     }
 }

--- a/src/test/java/org/semux/net/msg/p2p/handshake/v1/HelloMessageTest.java
+++ b/src/test/java/org/semux/net/msg/p2p/handshake/v1/HelloMessageTest.java
@@ -28,7 +28,7 @@ public class HelloMessageTest {
         assertTrue(msg.validate(config));
         assertEquals(key.toAddressString(), msg.getPeer().getPeerId());
 
-        msg = new HelloMessage(msg.getEncoded());
+        msg = new HelloMessage(msg.getBody());
         assertTrue(msg.validate(config));
         assertEquals(key.toAddressString(), msg.getPeer().getPeerId());
     }

--- a/src/test/java/org/semux/net/msg/p2p/handshake/v1/WorldMessageTest.java
+++ b/src/test/java/org/semux/net/msg/p2p/handshake/v1/WorldMessageTest.java
@@ -28,7 +28,7 @@ public class WorldMessageTest {
         assertTrue(msg.validate(config));
         assertEquals(key.toAddressString(), msg.getPeer().getPeerId());
 
-        msg = new WorldMessage(msg.getEncoded());
+        msg = new WorldMessage(msg.getBody());
         assertTrue(msg.validate(config));
         assertEquals(key.toAddressString(), msg.getPeer().getPeerId());
     }

--- a/src/test/java/org/semux/net/msg/p2p/handshake/v2/HelloMessageTest.java
+++ b/src/test/java/org/semux/net/msg/p2p/handshake/v2/HelloMessageTest.java
@@ -30,7 +30,7 @@ public class HelloMessageTest {
                 config.getClientId(), config.getClientCapabilities(), 2, Bytes.random(InitMessage.SECRET_LENGTH), key);
         assertTrue(msg.validate(config));
 
-        msg = new HelloMessage(msg.getEncoded());
+        msg = new HelloMessage(msg.getBody());
         assertTrue(msg.validate(config));
 
         String ip = "127.0.0.2";

--- a/src/test/java/org/semux/net/msg/p2p/handshake/v2/InitMessageTest.java
+++ b/src/test/java/org/semux/net/msg/p2p/handshake/v2/InitMessageTest.java
@@ -24,7 +24,7 @@ public class InitMessageTest {
         assertArrayEquals(secret, msg.getSecret());
         assertEquals(timestamp, msg.getTimestamp());
 
-        msg = new InitMessage(msg.getEncoded());
+        msg = new InitMessage(msg.getBody());
         assertArrayEquals(secret, msg.getSecret());
         assertEquals(timestamp, msg.getTimestamp());
     }

--- a/src/test/java/org/semux/net/msg/p2p/handshake/v2/WorldMessageTest.java
+++ b/src/test/java/org/semux/net/msg/p2p/handshake/v2/WorldMessageTest.java
@@ -30,7 +30,7 @@ public class WorldMessageTest {
                 config.getClientId(), config.getClientCapabilities(), 2, Bytes.random(InitMessage.SECRET_LENGTH), key);
         assertTrue(msg.validate(config));
 
-        msg = new WorldMessage(msg.getEncoded());
+        msg = new WorldMessage(msg.getBody());
         assertTrue(msg.validate(config));
 
         String ip = "127.0.0.2";


### PR DESCRIPTION
This PR intends to clean all P2P message codec. There are currently two types of codec being used:
- Simple codec;
- User-defined codec, especially for custom types.

The table below summarizes how the two types of codec are being used.

| Message type       | Simple codec | User-defined |
|--------------------|--------------|--------------|
| `DISCONNECT`       | YES          |              |
| `HELLO`            | YES          |              |
| `WORLD`            | YES          |              |
| `PING`             | YES          |              |
| `PONG`             | YES          |              |
| `GET_NODES`        | YES          |              |
| `NODES`            | YES          |              |
| `TRANSACTION`      |              | Transaction  |
| `HANDSHAKE_INIT`   | YES          |              |
| `HANDSHAKE_HELLO`  | YES          |              |
| `HANDSHAKE_WORLD`  | YES          |              |
| `GET_BLOCK`        | YES          |              |
| `BLOCK`            |              | Block        |
| `GET_BLOCK_HEADER` | YES          |              |
| `BLOCK_HEADER`     |              | BlockHeader  |
| `BFT_NEW_HEIGHT`   | YES          |              |
| `BFT_NEW_VIEW`     |              | Proof        |
| `BFT_PROPOSAL`     |              | Proposal     |
| `BFT_VOTE`         |              | Vote         |
