### PR TITLE
GUI: Fix editing the send panel address

### DIFF
--- a/src/main/java/org/semux/gui/panel/SendPanel.java
+++ b/src/main/java/org/semux/gui/panel/SendPanel.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.swing.ButtonGroup;
@@ -235,7 +236,7 @@ public class SendPanel extends JPanel implements ActionListener {
         clear();
     }
 
-    public String getToText() {
+    private String getToAddress() {
 
         Object selected = selectTo.getSelectedItem();
         String ret = "";
@@ -348,7 +349,8 @@ public class SendPanel extends JPanel implements ActionListener {
                 }
             }
 
-            Object toSelected = selectTo.getSelectedItem();
+            // in some cases, the getSelectedItem does not get user input until focus is left
+            Object toSelected = selectTo.getEditor().getItem();
 
             selectTo.removeAllItems();
             for (AccountItem accountItem : accountItems) {
@@ -369,7 +371,7 @@ public class SendPanel extends JPanel implements ActionListener {
             String data = getDataText();
 
             // decode0x recipient address
-            byte[] to = Hex.decode0x(getToText());
+            byte[] to = Hex.decode0x(getToAddress());
 
             if (acc == null) {
                 showErrorDialog(GuiMessages.get("SelectAccount"));


### PR DESCRIPTION
getSelectedItem doesn't work properly if still focused.
This can cause user edits to get reverted on update.