### PR TITLE
Trivial: Log invalid wallet format error

### DIFF
--- a/src/main/java/org/semux/core/Wallet.java
+++ b/src/main/java/org/semux/core/Wallet.java
@@ -142,7 +142,9 @@ public class Wallet {
             }
             this.password = password;
             return true;
-        } catch (CryptoException | InvalidKeySpecException e) {
+        } catch (CryptoException e) {
+            logger.error(e.getMessage());
+        } catch (InvalidKeySpecException e) {
             logger.error("Failed to decrypt the wallet data");
         } catch (IOException e) {
             logger.error("Failed to open wallet", e);


### PR DESCRIPTION
Currently if wallet format is newer, the error just says 'failed to
decrypt'

This is incorrect, as it is not a password problem.