### PR TITLE
API: Transaction result included in getTransaction

### DIFF
--- a/src/main/java/org/semux/api/v2/SemuxApiImpl.java
+++ b/src/main/java/org/semux/api/v2/SemuxApiImpl.java
@@ -298,7 +298,7 @@ public final class SemuxApiImpl implements SemuxApi {
 
         resp.setResult(kernel.getBlockchain().getTransactions(addressBytes, fromInt, toInt).parallelStream()
                 .map(tx -> TypeFactory.transactionType(
-                        kernel.getBlockchain().getTransactionBlockNumber(tx.getHash()), tx, null))
+                        kernel.getBlockchain().getTransactionBlockNumber(tx.getHash()), tx))
                 .collect(Collectors.toList()));
 
         return success(resp);
@@ -536,7 +536,7 @@ public final class SemuxApiImpl implements SemuxApi {
 
         TransactionResult result = kernel.getBlockchain().getTransactionResult(hashBytes);
 
-        resp.setResult(TypeFactory.transactionType(
+        resp.setResult(TypeFactory.fullTransactionType(
                 kernel.getBlockchain().getTransactionBlockNumber(transaction.getHash()),
                 transaction, result));
 

--- a/src/main/java/org/semux/api/v2/SemuxApiImpl.java
+++ b/src/main/java/org/semux/api/v2/SemuxApiImpl.java
@@ -68,6 +68,7 @@ import org.semux.core.BlockchainImpl;
 import org.semux.core.PendingManager;
 import org.semux.core.SyncManager;
 import org.semux.core.Transaction;
+import org.semux.core.TransactionResult;
 import org.semux.core.TransactionType;
 import org.semux.core.exception.WalletLockedException;
 import org.semux.core.state.Account;
@@ -297,7 +298,7 @@ public final class SemuxApiImpl implements SemuxApi {
 
         resp.setResult(kernel.getBlockchain().getTransactions(addressBytes, fromInt, toInt).parallelStream()
                 .map(tx -> TypeFactory.transactionType(
-                        kernel.getBlockchain().getTransactionBlockNumber(tx.getHash()), tx))
+                        kernel.getBlockchain().getTransactionBlockNumber(tx.getHash()), tx, null))
                 .collect(Collectors.toList()));
 
         return success(resp);
@@ -533,9 +534,11 @@ public final class SemuxApiImpl implements SemuxApi {
             return badRequest(resp, "The request transaction was not found");
         }
 
+        TransactionResult result = kernel.getBlockchain().getTransactionResult(hashBytes);
+
         resp.setResult(TypeFactory.transactionType(
                 kernel.getBlockchain().getTransactionBlockNumber(transaction.getHash()),
-                transaction));
+                transaction, result));
 
         return success(resp);
     }

--- a/src/main/java/org/semux/api/v2/TypeFactory.java
+++ b/src/main/java/org/semux/api/v2/TypeFactory.java
@@ -23,12 +23,14 @@ import org.semux.api.v2.model.InfoType;
 import org.semux.api.v2.model.PeerType;
 import org.semux.api.v2.model.PendingTransactionType;
 import org.semux.api.v2.model.TransactionLimitsType;
+import org.semux.api.v2.model.TransactionResultType;
 import org.semux.api.v2.model.TransactionType;
 import org.semux.core.Amount;
 import org.semux.core.Block;
 import org.semux.core.Blockchain;
 import org.semux.core.BlockchainImpl;
 import org.semux.core.Transaction;
+import org.semux.core.TransactionResult;
 import org.semux.core.state.Account;
 import org.semux.core.state.Delegate;
 import org.semux.crypto.Hex;
@@ -63,7 +65,7 @@ public class TypeFactory {
                 .stateRoot(Hex.encode0x(block.getStateRoot()))
                 .data(Hex.encode0x(block.getData()))
                 .transactions(txs.stream()
-                        .map(tx -> transactionType(block.getNumber(), tx))
+                        .map(tx -> transactionType(block.getNumber(), tx, null))
                         .collect(Collectors.toList()));
     }
 
@@ -136,7 +138,7 @@ public class TypeFactory {
                         transactionType.equals(DELEGATE) ? kernel.getConfig().minDelegateBurnAmount() : null));
     }
 
-    public static TransactionType transactionType(Long blockNumber, Transaction tx) {
+    public static TransactionType transactionType(Long blockNumber, Transaction tx, TransactionResult result) {
         return new TransactionType()
                 .blockNumber(String.valueOf(blockNumber))
                 .hash(Hex.encode0x(tx.getHash()))
@@ -147,7 +149,15 @@ public class TypeFactory {
                 .fee(encodeAmount(tx.getFee()))
                 .nonce(String.valueOf(tx.getNonce()))
                 .timestamp(String.valueOf(tx.getTimestamp()))
+                .transactionResult(transactionResultType(result))
                 .data(Hex.encode0x(tx.getData()));
+    }
+
+    private static TransactionResultType transactionResultType(TransactionResult result) {
+        // return new TransactionResultType()
+        // .(logInfoType(tx.get));
+        return null;
+
     }
 
     public static PendingTransactionType pendingTransactionType(Transaction tx) {

--- a/src/main/java/org/semux/api/v2/TypeFactory.java
+++ b/src/main/java/org/semux/api/v2/TypeFactory.java
@@ -168,7 +168,7 @@ public class TypeFactory {
                 .timestamp(String.valueOf(tx.getTimestamp()))
                 .data(Hex.encode0x(tx.getData()))
                 .gas(String.valueOf(tx.getGas()))
-                .gasPrice(String.valueOf(tx.getGas()));
+                .gasPrice(String.valueOf(tx.getGasPrice()));
     }
 
     private static TransactionResultType transactionResultType(TransactionResult result) {
@@ -198,7 +198,7 @@ public class TypeFactory {
                 .timestamp(String.valueOf(tx.getTimestamp()))
                 .data(Hex.encode0x(tx.getData()))
                 .gas(String.valueOf(tx.getGas()))
-                .gasPrice(String.valueOf(tx.getGas()));
+                .gasPrice(String.valueOf(tx.getGasPrice()));
     }
 
     public static String encodeAmount(Amount a) {

--- a/src/main/java/org/semux/api/v2/TypeFactory.java
+++ b/src/main/java/org/semux/api/v2/TypeFactory.java
@@ -175,6 +175,7 @@ public class TypeFactory {
         return new TransactionResultType()
                 .logs(result.getLogs().stream().map(TypeFactory::logInfoType).collect(Collectors.toList()))
                 .gasUsed(String.valueOf(result.getGasUsed()))
+                .code(result.getCode().name())
                 .returnData(Hex.encode0x(result.getReturnData()));
     }
 

--- a/src/main/resources/org/semux/api/swagger/v2.2.0.json
+++ b/src/main/resources/org/semux/api/swagger/v2.2.0.json
@@ -2562,6 +2562,10 @@
           "type": "string",
           "format": "int64",
           "pattern": "^\\d+$"
+        },
+        "code": {
+          "description": "The status of the transaction",
+          "type": "string"
         }
       }
     },

--- a/src/main/resources/org/semux/api/swagger/v2.2.0.json
+++ b/src/main/resources/org/semux/api/swagger/v2.2.0.json
@@ -1812,7 +1812,7 @@
         "transactions" : {
           "type" : "array",
           "items" : {
-            "$ref" : "#/definitions/TransactionType"
+            "$ref" : "#/definitions/BasicTransactionType"
           }
         }
       }
@@ -1934,7 +1934,7 @@
             "result" : {
               "type" : "array",
               "items" : {
-                "$ref" : "#/definitions/TransactionType"
+                "$ref" : "#/definitions/BasicTransactionType"
               }
             }
           }
@@ -2177,7 +2177,7 @@
         {
           "properties" : {
             "result" : {
-              "$ref" : "#/definitions/TransactionType"
+              "$ref" : "#/definitions/FullTransactionType"
             }
           }
         }
@@ -2395,8 +2395,9 @@
         }
       }
     },
-    "TransactionType" : {
+    "BasicTransactionType" : {
       "type" : "object",
+      "discriminator": "transactionType",
       "properties" : {
         "blockNumber" : {
           "type" : "string",
@@ -2449,13 +2450,36 @@
           "type" : "string",
           "pattern" : "^(0x)?[0-9a-fA-F]*$"
         },
-        "transactionResult" :
-        {
-          "description" : "Transaction results",
-          "type": "object",
-          "$ref": "#/definitions/TransactionResultType"
+        "gas" : {
+          "description" : "Gas supplied on call",
+          "type" : "string",
+          "format" : "int64",
+          "pattern" : "^\\d+$"
+        },
+        "gasPrice" : {
+          "description" : "Price per gas used",
+          "type" : "string",
+          "format" : "int64",
+          "pattern" : "^\\d+$"
         }
       }
+    },
+    "FullTransactionType": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/BasicTransactionType"
+        },
+        {
+          "properties": {
+            "transactionResult": {
+              "description": "Transaction results",
+              "type": "object",
+              "$ref": "#/definitions/TransactionResultType"
+            }
+          }
+        }
+      ]
     },
     "PendingTransactionType" : {
       "type" : "object",
@@ -2505,6 +2529,18 @@
           "description" : "Transaction data encoded in hexadecimal string",
           "type" : "string",
           "pattern" : "^(0x)?[0-9a-fA-F]*$"
+        },
+        "gas" : {
+          "description" : "Gas supplied on call",
+          "type" : "string",
+          "format" : "int64",
+          "pattern" : "^\\d+$"
+        },
+        "gasPrice" : {
+          "description" : "Price per gas used",
+          "type" : "string",
+          "format" : "int64",
+          "pattern" : "^\\d+$"
         }
       }
     },

--- a/src/main/resources/org/semux/api/swagger/v2.2.0.json
+++ b/src/main/resources/org/semux/api/swagger/v2.2.0.json
@@ -2448,6 +2448,12 @@
           "description" : "Transaction data encoded in hexadecimal string",
           "type" : "string",
           "pattern" : "^(0x)?[0-9a-fA-F]*$"
+        },
+        "transactionResult" :
+        {
+          "description" : "Transaction results",
+          "type": "object",
+          "$ref": "#/definitions/TransactionResultType"
         }
       }
     },
@@ -2499,6 +2505,49 @@
           "description" : "Transaction data encoded in hexadecimal string",
           "type" : "string",
           "pattern" : "^(0x)?[0-9a-fA-F]*$"
+        }
+      }
+    },
+    "TransactionResultType" : {
+      "type" : "object",
+      "properties" : {
+        "logs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LogInfoType"
+          }
+        },
+        "returnData": {
+          "description": "Return data encoded in hexadecimal string",
+          "type": "string",
+          "pattern": "^(0x)?[0-9a-fA-F]*$"
+        },
+        "gasUsed": {
+          "type": "string",
+          "format": "int64",
+          "pattern": "^\\d+$"
+        }
+      }
+    },
+    "LogInfoType": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "description": "Address encoded in hexadecimal string",
+          "type": "string",
+          "pattern": "^(0x)?[0-9a-fA-F]{64}$"
+        },
+        "data": {
+          "description": "Log info data encoded in hexadecimal string",
+          "type": "string",
+          "pattern": "^(0x)?[0-9a-fA-F]*$"
+        },
+        "topics": {
+          "description": "Topics encoded in hexadecimal string",
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
         }
       }
     },

--- a/src/test/java/org/semux/api/v2/SemuxApiTest.java
+++ b/src/test/java/org/semux/api/v2/SemuxApiTest.java
@@ -69,6 +69,7 @@ import org.junit.Test;
 import org.semux.Network;
 import org.semux.TestUtils;
 import org.semux.api.v2.model.AddNodeResponse;
+import org.semux.api.v2.model.BasicTransactionType;
 import org.semux.api.v2.model.BlockType;
 import org.semux.api.v2.model.ComposeRawTransactionResponse;
 import org.semux.api.v2.model.CreateAccountResponse;
@@ -225,7 +226,7 @@ public class SemuxApiTest extends SemuxApiTestBase {
         GetAccountTransactionsResponse response = api.getAccountTransactions(Hex.encode(tx.getFrom()), "0", "1024");
         assertTrue(response.isSuccess());
         assertNotNull(response.getResult());
-        for (TransactionType txType : response.getResult()) {
+        for (BasicTransactionType txType : response.getResult()) {
             assertEquals(block.getNumber(), Long.parseLong(txType.getBlockNumber()));
         }
     }

--- a/src/test/java/org/semux/api/v2/SemuxApiTest.java
+++ b/src/test/java/org/semux/api/v2/SemuxApiTest.java
@@ -100,7 +100,6 @@ import org.semux.api.v2.model.PeerType;
 import org.semux.api.v2.model.SignMessageResponse;
 import org.semux.api.v2.model.SignRawTransactionResponse;
 import org.semux.api.v2.model.SyncingProgressType;
-import org.semux.api.v2.model.TransactionType;
 import org.semux.api.v2.model.VerifyMessageResponse;
 import org.semux.consensus.SemuxSync;
 import org.semux.core.Amount;

--- a/src/test/java/org/semux/integration/TransactTest.java
+++ b/src/test/java/org/semux/integration/TransactTest.java
@@ -41,6 +41,7 @@ import org.semux.IntegrationTest;
 import org.semux.Kernel;
 import org.semux.Kernel.State;
 import org.semux.KernelMock;
+import org.semux.api.v2.model.BasicTransactionType;
 import org.semux.api.v2.model.DoTransactionResponse;
 import org.semux.api.v2.model.GetAccountResponse;
 import org.semux.api.v2.model.GetAccountTransactionsResponse;
@@ -296,7 +297,7 @@ public class TransactTest {
     private void assertLatestTransaction(KernelMock kernel, byte[] address,
             TransactionType type, byte[] from, byte[] to, Amount value, Amount fee, byte[] data)
             throws IOException {
-        org.semux.api.v2.model.TransactionType result = latestTransactionOf(kernel, address);
+        org.semux.api.v2.model.BasicTransactionType result = latestTransactionOf(kernel, address);
         assertEquals(type.name(), result.getType());
         assertEquals(Hex.encode0x(from), result.getFrom());
         assertEquals(Hex.encode0x(to), result.getTo());
@@ -351,7 +352,7 @@ public class TransactTest {
      * @return
      * @throws IOException
      */
-    private org.semux.api.v2.model.TransactionType latestTransactionOf(KernelMock kernel, byte[] address)
+    private org.semux.api.v2.model.BasicTransactionType latestTransactionOf(KernelMock kernel, byte[] address)
             throws IOException {
         SimpleApiClient apiClient = kernel.getApiClient();
 


### PR DESCRIPTION
If you request an individual transaction, we'll return the full object with transactionResult included.

if you are retrieving a block, we just leave it as a simple transaction without results as before.  We can change this in the future, but seems preferrable to prefer lighter weight calls unless necessary.

Also add gas information (gas, gasPrice, gasUsed) so that blockchain explorers can accurately show this along with calculating out actual fee (gasUsed*gasPrice)

