### PR TITLE
GUI: Make default alias for HD wallets more user friendly

### DIFF
--- a/src/main/java/org/semux/core/Wallet.java
+++ b/src/main/java/org/semux/core/Wallet.java
@@ -35,6 +35,7 @@ import org.semux.crypto.Aes;
 import org.semux.crypto.CryptoException;
 import org.semux.crypto.Hash;
 import org.semux.crypto.Key;
+import org.semux.message.GuiMessages;
 import org.semux.util.ByteArray;
 import org.semux.util.Bytes;
 import org.semux.util.FileUtil;
@@ -54,6 +55,9 @@ public class Wallet {
     private static final int BCRYPT_COST = 12;
     private static final Bip44 BIP_44 = new Bip44();
     private static final int MAX_HD_WALLET_SCAN_AHEAD = 20;
+
+    // the BIP-44 path prefix for semux addresses
+    private static final String PATH_PREFIX = "m/44'/7562605'/0'/0'";
 
     private final File file;
     private final org.semux.Network network;
@@ -440,11 +444,27 @@ public class Wallet {
             accounts.put(to, newKey);
             // set a default alias
             if (!aliases.containsKey(to)) {
-                setAddressAlias(newKey.toAddress(), address.getPath());
+                setAddressAlias(newKey.toAddress(), getAliasFromPath(address.getPath()));
             }
 
             return newKey;
         }
+    }
+
+    /**
+     * the full BIP-44 derivation path is confusing to new users
+     *
+     * So, we adapt this name to be simpler, and mostly concentrate on the index of
+     * the address.
+     *
+     * This method converts from a derivation path to a simplified form for default
+     * wallet alias
+     * 
+     * @param path
+     * @return
+     */
+    private String getAliasFromPath(String path) {
+        return path.replace(PATH_PREFIX, GuiMessages.get("HdWalletAliasPrefix"));
     }
 
     /**

--- a/src/main/java/org/semux/gui/panel/ReceivePanel.java
+++ b/src/main/java/org/semux/gui/panel/ReceivePanel.java
@@ -83,7 +83,7 @@ public class ReceivePanel extends JPanel implements ActionListener {
         table.setGridColor(Color.LIGHT_GRAY);
         table.setRowHeight(25);
         table.getTableHeader().setPreferredSize(new Dimension(10000, 24));
-        SwingUtil.setColumnWidths(table, 600, 0.05, 0.1, 0.55, 0.15, 0.15);
+        SwingUtil.setColumnWidths(table, 600, 0.05, 0.16, 0.55, 0.12, 0.12);
         SwingUtil.setColumnAlignments(table, false, false, false, true, true);
 
         table.getSelectionModel().addListSelectionListener(

--- a/src/main/resources/org/semux/gui/messages.properties
+++ b/src/main/resources/org/semux/gui/messages.properties
@@ -198,6 +198,7 @@ CreateHdWallet = Create wallet recovery phrase
 EnterNewHdPassword=HD key password
 HdWalletInstructions=<html>Creating HD wallet backup phrase<br>Please write this down safely so you can restore your wallet if<br>you lose your wallet file!  The password for the HD wallet does<br> not need to be the same as your wallet password.
 ReEnterNewHdPassword=Re-enter HD key password
+HdWalletAliasPrefix=HD/Semux
 
 # export private dialog
 ExportPrivateKey = Export private key


### PR DESCRIPTION
The derivation path in full was confusing, and too much useless information
Use a concise form of it for aliases in wallet (localized)

Also give slightly more default width to account alias column, so it does not get truncated.

fixes #95