### PR TITLE
CLI: Log bad password on exit.

### DIFF
--- a/src/main/java/org/semux/cli/SemuxCli.java
+++ b/src/main/java/org/semux/cli/SemuxCli.java
@@ -331,6 +331,7 @@ public class SemuxCli extends Launcher {
 
         Wallet wallet = loadWallet();
         if (!wallet.unlock(getPassword())) {
+            logger.error("Invalid password");
             SystemUtil.exit(SystemUtil.Code.FAILED_TO_UNLOCK_WALLET);
         }
         checkWalletHdInitialized(wallet);


### PR DESCRIPTION
we exit with correct exit code, but give user correct error.

fixes #93