### PR TITLE
Core: Testnet uses max 15 validators

### DIFF
--- a/src/main/java/org/semux/config/TestnetConfig.java
+++ b/src/main/java/org/semux/config/TestnetConfig.java
@@ -42,8 +42,7 @@ public class TestnetConfig extends AbstractConfig {
     @Override
     public int getNumberOfValidators(long number) {
 
-        // lazy fork to adjust number down to unstick testnet to more reasonable max
-        // number
+        // adjust number down to unstick testnet to more reasonable max
         if (number <= 751638) {
             return super.getNumberOfValidators(number);
         } else {

--- a/src/main/java/org/semux/config/TestnetConfig.java
+++ b/src/main/java/org/semux/config/TestnetConfig.java
@@ -41,6 +41,13 @@ public class TestnetConfig extends AbstractConfig {
      */
     @Override
     public int getNumberOfValidators(long number) {
-        return 15;
+
+        // lazy fork to adjust number down to unstick testnet to more reasonable max
+        // number
+        if (number <= 751638) {
+            return super.getNumberOfValidators(number);
+        } else {
+            return 15;
+        }
     }
 }

--- a/src/main/java/org/semux/config/TestnetConfig.java
+++ b/src/main/java/org/semux/config/TestnetConfig.java
@@ -31,4 +31,16 @@ public class TestnetConfig extends AbstractConfig {
     public Map<Fork, Long> forkActivationCheckpoints() {
         return Collections.emptyMap();
     }
+
+    /**
+     * Testnet maxes out at 15 validators to stop dead validators from breaking
+     * concensus
+     * 
+     * @param number
+     * @return
+     */
+    @Override
+    public int getNumberOfValidators(long number) {
+        return 15;
+    }
 }

--- a/src/main/java/org/semux/consensus/SemuxBft.java
+++ b/src/main/java/org/semux/consensus/SemuxBft.java
@@ -670,7 +670,15 @@ public class SemuxBft implements BftManager {
      * Update the validator sets.
      */
     protected void updateValidators() {
+        int maxValidators = config.getNumberOfValidators(height);
+
         validators = chain.getValidators();
+        // if the chain is reporting a larger number of validators
+        // then a configuration change has occurred (like a stuck testnet)
+        // so honor the configuration value
+        if (validators.size() > maxValidators) {
+            validators = validators.subList(0, maxValidators - 1);
+        }
         activeValidators = channelMgr.getActiveChannels(validators);
         lastUpdate = TimeUtil.currentTimeMillis();
     }

--- a/src/main/java/org/semux/consensus/SemuxBft.java
+++ b/src/main/java/org/semux/consensus/SemuxBft.java
@@ -677,7 +677,7 @@ public class SemuxBft implements BftManager {
         // then a configuration change has occurred (like a stuck testnet)
         // so honor the configuration value
         if (validators.size() > maxValidators) {
-            validators = validators.subList(0, maxValidators - 1);
+            validators = validators.subList(0, maxValidators);
         }
         activeValidators = channelMgr.getActiveChannels(validators);
         lastUpdate = TimeUtil.currentTimeMillis();


### PR DESCRIPTION
Testnet keeps dying because of dead validators.

Let's limit the number of validators to 15 such that we can
vote up alive validators to keep testnet healthy.

As testnet is already hung, do not need hardfork for this.