### PR TITLE
Core: Revert to using ceil for 2/3 vote

### DIFF
--- a/src/main/java/org/semux/consensus/VoteSet.java
+++ b/src/main/java/org/semux/consensus/VoteSet.java
@@ -53,7 +53,7 @@ public class VoteSet {
         this.view = view;
 
         this.validators = new HashSet<>(validators);
-        this.twoThirds = (int) Math.round(validators.size() * 2.0 / 3.0);
+        this.twoThirds = (int) Math.ceil(validators.size() * 2.0 / 3.0);
     }
 
     /**


### PR DESCRIPTION
Maybe @cryptokat can clarify, but doing a round here for initial blocks
(2 validators), will allow for both to propose and accept disparate
blocks.

I'm not sure case where round was necessary over ceil, if that is the case
we can just add a check where validators == 2 to fix.

Note: merging this into RC3 then down to various PRs will fix CI that is failing.