### PR TITLE
Concensus: Keep signalling VM fork past acceptance.

### DIFF
--- a/src/main/java/org/semux/core/BlockchainImpl.java
+++ b/src/main/java/org/semux/core/BlockchainImpl.java
@@ -628,8 +628,17 @@ public class BlockchainImpl implements Blockchain {
                 && latestBlock.getNumber() + 1 <= UNIFORM_DISTRIBUTION.activationDeadline) {
             set.add(UNIFORM_DISTRIBUTION);
         }
+
+        /**
+         * For prior forks, if a validator did not update, their node would stop syncing
+         * at point of fork. However, VM will only stop syncing at point a smart
+         * contract is created.
+         *
+         * Because of this, we need to keep signalling until activation deadline, rather
+         * than short circuiting (or until all nodes are shown to be updated).
+         */
         if (config.forkVirtualMachineEnabled()
-                && !forks.isActivated(VIRTUAL_MACHINE)
+                // && !forks.isActivated(VIRTUAL_MACHINE)
                 && latestBlock.getNumber() + 1 <= VIRTUAL_MACHINE.activationDeadline) {
             set.add(VIRTUAL_MACHINE);
         }


### PR DESCRIPTION
Prior forks would stop sycning at point of activation,
but with VM, it will only stop working when a new CREATE
or CALL type is used.

Keep signalling VM until activation deadline or such a point
we remove this check in future release.

fixes #106 