### PR TITLE
Add GET_BLOCK_PARTS message

### DIFF
--- a/src/main/java/org/semux/core/Block.java
+++ b/src/main/java/org/semux/core/Block.java
@@ -29,6 +29,38 @@ import static org.semux.core.Amount.sum;
  * Represents a block in the blockchain.
  */
 public class Block {
+
+    public enum BlockPart {
+        HEADER(1 << 0), TRANSACTIONS(1 << 1), RECEIPTS(1 << 2), VOTES(1 << 3);
+
+        private int code;
+
+        BlockPart(int code) {
+            this.code = code;
+        }
+
+        public static int parts(BlockPart... parts) {
+            int result = 0;
+            for (BlockPart part : parts) {
+                result |= part.code;
+            }
+            return result;
+        }
+
+        public List<BlockPart> parts(int parts) {
+            List<BlockPart> result = new ArrayList<>();
+            // NOTE: values() returns an array containing all of the values of the enum type
+            // in the order they are declared.
+            for (BlockPart bp : BlockPart.values()) {
+                if ((parts & bp.code) != 0) {
+                    result.add(bp);
+                }
+            }
+
+            return result;
+        }
+    }
+
     static final Logger logger = LoggerFactory.getLogger(Block.class);
 
     /**

--- a/src/main/java/org/semux/net/SemuxP2pHandler.java
+++ b/src/main/java/org/semux/net/SemuxP2pHandler.java
@@ -450,6 +450,10 @@ public class SemuxP2pHandler extends SimpleChannelInboundHandler<Message> {
             sync.onMessage(channel, msg);
             break;
         }
+        case GET_BLOCK_PARTS:
+        case BLOCK_PARTS:
+            // TODO: add handler
+            break;
         default:
             throw new UnreachableException();
         }

--- a/src/main/java/org/semux/net/msg/MessageCode.java
+++ b/src/main/java/org/semux/net/msg/MessageCode.java
@@ -91,6 +91,16 @@ public enum MessageCode {
      */
     BLOCK_HEADER(0x33),
 
+    /**
+     * [0x34] Request parts of a block from the peer.
+     */
+    GET_BLOCK_PARTS(0x34),
+
+    /**
+     * [0x35] Response containing the block parts.
+     */
+    BLOCK_PARTS(0x35),
+
     // =======================================
     // [0x40, 0x4f] Reserved for BFT
     // =======================================

--- a/src/main/java/org/semux/net/msg/MessageFactory.java
+++ b/src/main/java/org/semux/net/msg/MessageFactory.java
@@ -9,8 +9,10 @@ package org.semux.net.msg;
 import org.semux.crypto.Hex;
 import org.semux.net.msg.consensus.BlockHeaderMessage;
 import org.semux.net.msg.consensus.BlockMessage;
+import org.semux.net.msg.consensus.BlockPartsMessage;
 import org.semux.net.msg.consensus.GetBlockHeaderMessage;
 import org.semux.net.msg.consensus.GetBlockMessage;
+import org.semux.net.msg.consensus.GetBlockPartsMessage;
 import org.semux.net.msg.consensus.NewHeightMessage;
 import org.semux.net.msg.consensus.NewViewMessage;
 import org.semux.net.msg.consensus.ProposalMessage;
@@ -85,6 +87,10 @@ public class MessageFactory {
                 return new GetBlockHeaderMessage(body);
             case BLOCK_HEADER:
                 return new BlockHeaderMessage(body);
+            case GET_BLOCK_PARTS:
+                return new GetBlockPartsMessage(body);
+            case BLOCK_PARTS:
+                return new BlockPartsMessage(body);
 
             case BFT_NEW_HEIGHT:
                 return new NewHeightMessage(body);

--- a/src/main/java/org/semux/net/msg/consensus/BlockPartsMessage.java
+++ b/src/main/java/org/semux/net/msg/consensus/BlockPartsMessage.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2017-2018 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.net.msg.consensus;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.semux.net.msg.Message;
+import org.semux.net.msg.MessageCode;
+import org.semux.util.SimpleDecoder;
+import org.semux.util.SimpleEncoder;
+
+public class BlockPartsMessage extends Message {
+
+    private final long number;
+    private final int parts;
+    private final List<byte[]> data;
+
+    public BlockPartsMessage(int number, int parts, List<byte[]> data) {
+        super(MessageCode.BLOCK_PARTS, null);
+
+        this.number = number;
+        this.parts = parts;
+        this.data = data;
+
+        SimpleEncoder enc = new SimpleEncoder();
+        enc.writeLong(number);
+        enc.writeInt(parts);
+        enc.writeInt(data.size());
+        for (byte[] b : data) {
+            enc.writeBytes(b);
+        }
+        this.body = enc.toBytes();
+    }
+
+    public BlockPartsMessage(byte[] body) {
+        super(MessageCode.BLOCK_PARTS, null);
+
+        SimpleDecoder dec = new SimpleDecoder(body);
+        this.number = dec.readLong();
+        this.parts = dec.readInt();
+        this.data = new ArrayList<>();
+        int n = dec.readInt();
+        for (int i = 0; i < n; i++) {
+            data.add(dec.readBytes());
+        }
+
+        this.body = body;
+    }
+
+    public long getNumber() {
+        return number;
+    }
+
+    public int getParts() {
+        return parts;
+    }
+
+    public List<byte[]> getData() {
+        return data;
+    }
+
+    @Override
+    public String toString() {
+        return "BlockPartsMessage [number=" + number + ", parts=" + parts + "]";
+    }
+}

--- a/src/main/java/org/semux/net/msg/consensus/GetBlockPartsMessage.java
+++ b/src/main/java/org/semux/net/msg/consensus/GetBlockPartsMessage.java
@@ -13,11 +13,6 @@ import org.semux.util.SimpleEncoder;
 
 public class GetBlockPartsMessage extends Message {
 
-    public static final int BLOCK_HEADER = 1 << 0;
-    public static final int BLOCK_TRANSACTIONS = 1 << 1;
-    public static final int BLOCK_RESULTS = 1 << 2;
-    public static final int BLOCK_VOTES = 1 << 3;
-
     private final long number;
     private final int parts;
 

--- a/src/main/java/org/semux/net/msg/consensus/GetBlockPartsMessage.java
+++ b/src/main/java/org/semux/net/msg/consensus/GetBlockPartsMessage.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2017-2018 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.net.msg.consensus;
+
+import org.semux.net.msg.Message;
+import org.semux.net.msg.MessageCode;
+import org.semux.util.SimpleDecoder;
+import org.semux.util.SimpleEncoder;
+
+public class GetBlockPartsMessage extends Message {
+
+    public static final int BLOCK_HEADER = 1 << 0;
+    public static final int BLOCK_TRANSACTIONS = 1 << 1;
+    public static final int BLOCK_RESULTS = 1 << 2;
+    public static final int BLOCK_VOTES = 1 << 3;
+
+    private final long number;
+    private final int parts;
+
+    public GetBlockPartsMessage(long number, int parts) {
+        super(MessageCode.GET_BLOCK_PARTS, BlockPartsMessage.class);
+
+        this.number = number;
+        this.parts = parts;
+
+        SimpleEncoder enc = new SimpleEncoder();
+        enc.writeLong(number);
+        enc.writeInt(parts);
+        this.body = enc.toBytes();
+    }
+
+    public GetBlockPartsMessage(byte[] body) {
+        super(MessageCode.GET_BLOCK_PARTS, BlockPartsMessage.class);
+
+        SimpleDecoder dec = new SimpleDecoder(body);
+        this.number = dec.readLong();
+        this.parts = dec.readInt();
+
+        this.body = body;
+    }
+
+    public long getNumber() {
+        return number;
+    }
+
+    public int getParts() {
+        return parts;
+    }
+
+    @Override
+    public String toString() {
+        return "GetBlockPartsMessage [number=" + number + ", parts = " + parts + "]";
+    }
+}


### PR DESCRIPTION
I'd propose to add two message types to support light clients. 
- `GET_BLOCK_PARTS` - block parts (header, transaction, receipts, votes) request
- `BLOCK_PARTS` - block parts response

In the short-term, we can use these protocols to speed up the syncing  by not requesting block votes.