### PR TITLE
Trivial: formatting newlines for static imports

### DIFF
--- a/src/main/java/org/semux/gui/SwingUtil.java
+++ b/src/main/java/org/semux/gui/SwingUtil.java
@@ -7,6 +7,7 @@
 package org.semux.gui;
 
 import static java.util.Arrays.stream;
+
 import static org.semux.core.Amount.Unit.SEM;
 import static org.semux.gui.TextContextMenuItem.COPY;
 import static org.semux.gui.TextContextMenuItem.CUT;

--- a/src/test/java/org/semux/api/http/HttpHandlerTest.java
+++ b/src/test/java/org/semux/api/http/HttpHandlerTest.java
@@ -8,6 +8,7 @@ package org.semux.api.http;
 
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
+
 import static junit.framework.TestCase.assertTrue;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/semux/core/WalletTest.java
+++ b/src/test/java/org/semux/core/WalletTest.java
@@ -7,6 +7,7 @@
 package org.semux.core;
 
 import static java.nio.file.attribute.PosixFilePermission.OTHERS_READ;
+
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/org/semux/integration/SyncingTest.java
+++ b/src/test/java/org/semux/integration/SyncingTest.java
@@ -7,6 +7,7 @@
 package org.semux.integration;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertTrue;
 import static org.semux.core.Amount.Unit.SEM;

--- a/src/test/java/org/semux/integration/TransactTest.java
+++ b/src/test/java/org/semux/integration/TransactTest.java
@@ -7,6 +7,7 @@
 package org.semux.integration;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;

--- a/src/test/java/org/semux/util/IOUtilTest.java
+++ b/src/test/java/org/semux/util/IOUtilTest.java
@@ -7,6 +7,7 @@
 package org.semux.util;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
When running `mvn clean install` these newlines get added.

It gets old removing these files from commits.  If there's a suggestion
on how to get them consistent between devs, I'm all ears.