### PR TITLE
Core: Fix pending manager nonce check.

### DIFF
--- a/src/main/java/org/semux/core/PendingManager.java
+++ b/src/main/java/org/semux/core/PendingManager.java
@@ -181,7 +181,7 @@ public class PendingManager implements Runnable, BlockchainListener {
      */
     public synchronized ProcessingResult addTransactionSync(Transaction tx) {
         // nonce check for transactions from this client
-        if (tx.getNonce() != kernel.getBlockchain().getAccountState().getAccount(tx.getFrom()).getNonce()) {
+        if (tx.getNonce() != getNonce(tx.getFrom())) {
             return new ProcessingResult(0, TransactionResult.Code.INVALID_NONCE);
         }
 


### PR DESCRIPTION
Need to get expected nonce from pending manager, not from stored chain,
as other transactions could have already update nonce for this block.

Fixes #200 