### PR TITLE
VM: Fix block gas limit

### DIFF
--- a/src/main/java/org/semux/config/AbstractConfig.java
+++ b/src/main/java/org/semux/config/AbstractConfig.java
@@ -51,7 +51,7 @@ public abstract class AbstractConfig implements Config, ChainSpec {
     // =========================
     // Chain spec
     // =========================
-    protected long maxBlockGasLimit = 20_000_000L; // 20m gas
+    protected long maxBlockGasLimit = 30_000_000L; // 30m gas
     protected Amount minTransactionFee = Amount.of(5, MILLI_SEM);
     protected Amount minDelegateBurnAmount = Amount.of(1000, SEM);
     protected long nonVMTransactionGasCost = 5_000L;


### PR DESCRIPTION
## Description

As mentioned in bug, current mainnet has blocks up to around 5600 TXs from perf tests.
Since standard transfers cost 5,000, we set 6,000 limit, so max block gas would be 30mil to be able to sync and maintain parity with old mainnet.

Note: Currently validators will only propose up to 10mil by default configuration, but at least they'll be able to sync.  Going with 10 million for first version of VM seems appropriate for default maxes to keep validator from being overwhelmed.


## Test Plan

tested via bug, as well as able to get 9999 transfers in testnet successfully


## Related issues and/or PRs

Fixes #242 
