### PR TITLE
DB: index internal transactions by account

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
                             <goal>generate</goal>
                         </goals>
                         <configuration>
-                            <inputSpec>${project.basedir}/src/main/resources/org/semux/api/swagger/v2.3.0.json</inputSpec>
+                            <inputSpec>${project.basedir}/src/main/resources/org/semux/api/swagger/v2.4.0.json</inputSpec>
                             <language>jaxrs-cxf</language>
                             <configOptions>
                                 <useGenericResponse>true</useGenericResponse>
@@ -138,7 +138,7 @@
                             <goal>generate</goal>
                         </goals>
                         <configuration>
-                            <inputSpec>${project.basedir}/src/main/resources/org/semux/api/swagger/v2.3.0.json</inputSpec>
+                            <inputSpec>${project.basedir}/src/main/resources/org/semux/api/swagger/v2.4.0.json</inputSpec>
                             <language>jaxrs-cxf-client</language>
                             <configOptions>
                                 <useBeanValidation>false</useBeanValidation>

--- a/src/main/java/org/semux/api/ApiHandlerImpl.java
+++ b/src/main/java/org/semux/api/ApiHandlerImpl.java
@@ -61,6 +61,7 @@ public class ApiHandlerImpl implements ApiHandler {
         this.routes.put(ApiVersion.v2_1_0, routesV2);
         this.routes.put(ApiVersion.v2_2_0, routesV2);
         this.routes.put(ApiVersion.v2_3_0, routesV2);
+        this.routes.put(ApiVersion.v2_4_0, routesV2);
     }
 
     @Override

--- a/src/main/java/org/semux/api/ApiVersion.java
+++ b/src/main/java/org/semux/api/ApiVersion.java
@@ -32,9 +32,11 @@ public enum ApiVersion {
 
     v2_2_0("v2.2.0"),
 
-    v2_3_0("v2.3.0");
+    v2_3_0("v2.3.0"),
 
-    public final static ApiVersion DEFAULT = v2_3_0;
+    v2_4_0("v2.4.0");
+
+    public final static ApiVersion DEFAULT = v2_4_0;
 
     public final String prefix;
 

--- a/src/main/java/org/semux/api/v2/TypeFactory.java
+++ b/src/main/java/org/semux/api/v2/TypeFactory.java
@@ -44,13 +44,15 @@ import org.semux.vm.client.SemuxInternalTransaction;
 
 public class TypeFactory {
 
-    public static AccountType accountType(Account account, int transactionCount, int pendingTransactionCount) {
+    public static AccountType accountType(Account account, int transactionCount, int internalTransactionCount,
+            int pendingTransactionCount) {
         return new AccountType()
                 .address(Hex.encode0x(account.getAddress()))
                 .available(encodeAmount(account.getAvailable()))
                 .locked(encodeAmount(account.getLocked()))
                 .nonce(String.valueOf(account.getNonce()))
                 .transactionCount(transactionCount)
+                .internalTransactionCount(internalTransactionCount)
                 .pendingTransactionCount(pendingTransactionCount);
     }
 
@@ -186,8 +188,9 @@ public class TypeFactory {
                         .collect(Collectors.toList()));
     }
 
-    private static InternalTransactionType internalTransactionType(SemuxInternalTransaction it) {
+    public static InternalTransactionType internalTransactionType(SemuxInternalTransaction it) {
         return new InternalTransactionType()
+                .rootTransactionHash(Hex.encode0x(it.getRootTxHash()))
                 .rejected(it.isRejected())
                 .depth(Integer.toString(it.getDepth()))
                 .index(Integer.toString(it.getIndex()))

--- a/src/main/java/org/semux/core/Blockchain.java
+++ b/src/main/java/org/semux/core/Blockchain.java
@@ -12,6 +12,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.semux.core.BlockchainImpl.ValidatorStats;
 import org.semux.core.state.AccountState;
 import org.semux.core.state.DelegateState;
+import org.semux.vm.client.SemuxInternalTransaction;
 
 public interface Blockchain {
 
@@ -154,6 +155,28 @@ public interface Blockchain {
      * @return
      */
     List<Transaction> getTransactions(byte[] address, int from, int to);
+
+    /**
+     * Returns the total number of internal transactions from/to the given address.
+     *
+     * @param address
+     *            account address
+     * @return
+     */
+    int getInternalTransactionCount(byte[] address);
+
+    /**
+     * Returns internal transactions from/to an address.
+     *
+     * @param address
+     *            account address
+     * @param from
+     *            transaction index from
+     * @param to
+     *            transaction index to
+     * @return
+     */
+    List<SemuxInternalTransaction> getInternalTransactions(byte[] address, int from, int to);
 
     /**
      * Add a block to the chain.

--- a/src/main/java/org/semux/core/BlockchainImpl.java
+++ b/src/main/java/org/semux/core/BlockchainImpl.java
@@ -219,7 +219,7 @@ public class BlockchainImpl implements Blockchain {
 
     @Override
     public Block getBlock(long number) {
-        return getBlock(blockDB, number);
+        return getBlock(blockDB, number, false);
     }
 
     @Override
@@ -949,7 +949,7 @@ public class BlockchainImpl implements Blockchain {
             long latestBlockNumber = (bytes == null) ? 0 : Bytes.toLong(bytes);
             long target = Math.min(latestBlockNumber, to);
             for (long i = 1; i <= target; i++) {
-                boolean result = tempChain.importBlock(getBlock(blockDB, i), false);
+                boolean result = tempChain.importBlock(getBlock(blockDB, i, true), false);
                 if (!result) {
                     break;
                 }
@@ -979,10 +979,10 @@ public class BlockchainImpl implements Blockchain {
 
     // THE FOLLOWING TYPE ID SHOULD NEVER CHANGE
 
-    private static Block getBlock(Database blockDB, long number) {
+    private static Block getBlock(Database blockDB, long number, boolean skipResults) {
         byte[] header = blockDB.get(Bytes.merge(TYPE_BLOCK_HEADER_BY_NUMBER, Bytes.of(number)));
         byte[] transactions = blockDB.get(Bytes.merge(TYPE_BLOCK_TRANSACTIONS_BY_NUMBER, Bytes.of(number)));
-        byte[] results = blockDB.get(Bytes.merge(TYPE_BLOCK_RESULTS_BY_NUMBER, Bytes.of(number)));
+        byte[] results = skipResults ? null : blockDB.get(Bytes.merge(TYPE_BLOCK_RESULTS_BY_NUMBER, Bytes.of(number)));
         byte[] votes = blockDB.get(Bytes.merge(TYPE_BLOCK_VOTES_BY_NUMBER, Bytes.of(number)));
 
         return (header == null) ? null : Block.fromComponents(header, transactions, results, votes);

--- a/src/main/java/org/semux/core/BlockchainImpl.java
+++ b/src/main/java/org/semux/core/BlockchainImpl.java
@@ -585,9 +585,7 @@ public class BlockchainImpl implements Blockchain {
         for (int i = from; i < total && i < to; i++) {
             byte[] key = getNthInternalTransactionIndexKey(address, i);
             byte[] value = indexDB.get(key);
-            // byte[] rootTransactionHash = Arrays.copyOfRange(value, 0, 32);
-            byte[] internalTransaction = Arrays.copyOfRange(value, 32, value.length);
-            list.add(TransactionResult.deserializeInternalTransaction(internalTransaction));
+            list.add(SemuxInternalTransaction.fromBytes(value));
         }
 
         return list;
@@ -610,13 +608,8 @@ public class BlockchainImpl implements Blockchain {
      * @param address
      */
     protected void addInternalTransactionToAccount(Transaction root, SemuxInternalTransaction tx, byte[] address) {
-        byte[] value = Bytes.merge(
-                root.getHash(), // root transaction hash
-                TransactionResult.serializeInternalTransaction(tx) // serialized internal transaction
-        );
-
         int total = getInternalTransactionCount(address);
-        indexDB.put(getNthInternalTransactionIndexKey(address, total), value);
+        indexDB.put(getNthInternalTransactionIndexKey(address, total), tx.toBytes());
         setInternalTransactionCount(address, total + 1);
     }
 

--- a/src/main/java/org/semux/core/TransactionExecutor.java
+++ b/src/main/java/org/semux/core/TransactionExecutor.java
@@ -323,7 +323,7 @@ public class TransactionExecutor {
             result.setBlockNumber(block.getNumber());
             result.setInternalTransactions(receipt.getInternalTransactions()
                     .stream()
-                    .map(SemuxInternalTransaction::new)
+                    .map(it -> new SemuxInternalTransaction(tx.getHash(), it))
                     .collect(Collectors.toList()));
 
             // log the transaction result

--- a/src/main/resources/org/semux/api/swagger/v2.4.0.json
+++ b/src/main/resources/org/semux/api/swagger/v2.4.0.json
@@ -60,6 +60,11 @@
                     "type": "integer",
                     "format": "int32"
                 },
+                "internalTransactionCount": {
+                    "description": "The number of internal transactions received/sent",
+                    "type": "integer",
+                    "format": "int32"
+                },
                 "pendingTransactionCount": {
                     "description": "The number of pending transaction from/to this account",
                     "type": "integer",
@@ -256,6 +261,24 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/TransactionType"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "GetAccountInternalTransactionsResponse": {
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/InternalTransactionType"
                             }
                         }
                     }
@@ -895,6 +918,11 @@
         "InternalTransactionType": {
             "type": "object",
             "properties": {
+                "rootTransactionHash": {
+                    "description": "The root transaction hash",
+                    "type": "string",
+                    "pattern": "^(0x)?[0-9a-fA-F]{64}$"
+                },
                 "rejected": {
                     "description": "Whether this transaction is rejected",
                     "type": "boolean"
@@ -912,7 +940,7 @@
                     "pattern": "^\\d+$"
                 },
                 "type": {
-                    "description" : "Call type, possibly CALL, DELEGATECALL, CALLCODE, CREATE",
+                    "description" : "Call type, possibly CALL, DELEGATECALL, CALLCODE, CREATE, CREATE2",
                     "type": "string"
                 },
                 "from": {
@@ -1470,6 +1498,66 @@
                         "description": "successful operation",
                         "schema": {
                             "$ref": "#/definitions/GetAccountTransactionsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/account/internal-transactions": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Get account internal transactions",
+                "description": "Returns internal transactions from/to an account.",
+                "operationId": "getAccountInternalTransactions",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "address",
+                        "in": "query",
+                        "description": "Address of account",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    },
+                    {
+                        "name": "from",
+                        "in": "query",
+                        "description": "Starting range of transactions",
+                        "required": true,
+                        "type": "string",
+                        "format": "int32",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "to",
+                        "in": "query",
+                        "description": "Ending range of transactions",
+                        "required": true,
+                        "type": "string",
+                        "format": "int32",
+                        "pattern": "^\\d+$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/GetAccountInternalTransactionsResponse"
                         }
                     },
                     "400": {

--- a/src/main/resources/org/semux/api/swagger/v2.4.0.json
+++ b/src/main/resources/org/semux/api/swagger/v2.4.0.json
@@ -1,0 +1,3209 @@
+{
+    "basePath": "/v2.4.0",
+    "consumes": [
+        "application/x-www-form-urlencoded"
+    ],
+    "definitions": {
+        "ApiHandlerResponse": {
+            "type": "object",
+            "discriminator": "ApiHandlerResponse",
+            "required": [
+                "success"
+            ],
+            "properties": {
+                "success": {
+                    "description": "Whether this operation was processed successfully",
+                    "type": "boolean"
+                },
+                "message": {
+                    "description": "Success/error message",
+                    "type": "string"
+                }
+            }
+        },
+        "GetRootResponse": {
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                }
+            ]
+        },
+        "AccountType": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "description": "The address of this account",
+                    "type": "string",
+                    "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                },
+                "available": {
+                    "description": "The available balance of this account",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "locked": {
+                    "description": "The locked balance of this account",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "nonce": {
+                    "description": "The nonce of this account",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "transactionCount": {
+                    "description": "The number of transactions received/sent",
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "pendingTransactionCount": {
+                    "description": "The number of pending transaction from/to this account",
+                    "type": "integer",
+                    "format": "int32"
+                }
+            }
+        },
+        "AddNodeResponse": {
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                }
+            ]
+        },
+        "BlockType": {
+            "type": "object",
+            "properties": {
+                "hash": {
+                    "description": "The block hash",
+                    "type": "string",
+                    "pattern": "^(0x)?[0-9a-fA-F]{64}$"
+                },
+                "number": {
+                    "description": "The block number",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "view": {
+                    "description": "The view number. # of additional BFT rounds to generated this block",
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "coinbase": {
+                    "description": "The block producer's address",
+                    "type": "string",
+                    "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                },
+                "parentHash": {
+                    "description": "The hash of the parent block",
+                    "type": "string",
+                    "pattern": "^(0x)?[0-9a-fA-F]{64}$"
+                },
+                "timestamp": {
+                    "description": "Block timestamp in milliseconds specified by the block producer.",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "transactionsRoot": {
+                    "description": "The Merkle root hash of the transactions",
+                    "type": "string",
+                    "pattern": "^(0x)?[0-9a-fA-F]{64}$"
+                },
+                "resultsRoot": {
+                    "description": "The Merkle root hash of the results",
+                    "type": "string",
+                    "pattern": "^(0x)?[0-9a-fA-F]{64}$"
+                },
+                "stateRoot": {
+                    "description": "The state root hash. Not enabled yet!",
+                    "type": "string",
+                    "pattern": "^(0x)?[0-9a-fA-F]{64}$"
+                },
+                "data": {
+                    "description": "The extra data of this block",
+                    "type": "string",
+                    "pattern": "^(0x)?[0-9a-fA-F]*$"
+                },
+                "transactions": {
+                    "description": "A list of transaction in the block",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TransactionType"
+                    }
+                }
+            }
+        },
+        "CreateAccountResponse": {
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "description": "The address of the newly created account",
+                            "type": "string",
+                            "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                        }
+                    }
+                }
+            ]
+        },
+        "DelegateType": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "description": "Delegate address",
+                    "type": "string",
+                    "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                },
+                "name": {
+                    "description": "Delegate name",
+                    "type": "string"
+                },
+                "registeredAt": {
+                    "description": "Delegate registration block number",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "votes": {
+                    "description": "Total votes of the delegate",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "blocksForged": {
+                    "description": "The number of blocks produced by this delegate",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "turnsHit": {
+                    "description": "Forged blocks when the delegate is a primary validator",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "turnsMissed": {
+                    "description": "Missed blocks when the delegate is a primary validator",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "validator": {
+                    "description": "Whether the delegate is currently a validator",
+                    "type": "boolean"
+                }
+            }
+        },
+        "DoTransactionResponse": {
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "description": "The transaction hash",
+                            "type": "string",
+                            "pattern": "^(0x)?[0-9a-fA-F]{64}$"
+                        }
+                    }
+                }
+            ]
+        },
+        "GetAccountResponse": {
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "$ref": "#/definitions/AccountType"
+                        }
+                    }
+                }
+            ]
+        },
+        "DeleteAccountResponse": {
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                }
+            ]
+        },
+        "GetAccountTransactionsResponse": {
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/TransactionType"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "GetAccountPendingTransactionsResponse": {
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/TransactionType"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "GetAccountVotesResponse": {
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AccountVoteType"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "AccountVoteType": {
+            "type": "object",
+            "properties": {
+                "delegate": {
+                    "$ref": "#/definitions/DelegateType"
+                },
+                "votes": {
+                    "description": "Total votes from this account to the delegate",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                }
+            }
+        },
+        "GetBlockResponse": {
+            "type": "object",
+            "required": [
+                "success"
+            ],
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "$ref": "#/definitions/BlockType"
+                        }
+                    }
+                }
+            ]
+        },
+        "GetDelegateResponse": {
+            "type": "object",
+            "required": [
+                "success"
+            ],
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "$ref": "#/definitions/DelegateType"
+                        }
+                    }
+                }
+            ]
+        },
+        "GetDelegatesResponse": {
+            "type": "object",
+            "required": [
+                "success"
+            ],
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DelegateType"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "GetInfoResponse": {
+            "type": "object",
+            "required": [
+                "success"
+            ],
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "$ref": "#/definitions/InfoType"
+                        }
+                    }
+                }
+            ]
+        },
+        "GetLatestBlockNumberResponse": {
+            "type": "object",
+            "required": [
+                "success"
+            ],
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "description": "The number of the latest block",
+                            "type": "string",
+                            "format": "int64",
+                            "pattern": "^\\d+$"
+                        }
+                    }
+                }
+            ]
+        },
+        "GetLatestBlockResponse": {
+            "type": "object",
+            "required": [
+                "success"
+            ],
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "$ref": "#/definitions/BlockType"
+                        }
+                    }
+                }
+            ]
+        },
+        "GetPeersResponse": {
+            "type": "object",
+            "required": [
+                "success"
+            ],
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/PeerType"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "GetPendingTransactionsResponse": {
+            "type": "object",
+            "required": [
+                "success"
+            ],
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/TransactionType"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "GetTransactionLimitsResponse": {
+            "type": "object",
+            "required": [
+                "success"
+            ],
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "$ref": "#/definitions/TransactionLimitsType"
+                        }
+                    }
+                }
+            ]
+        },
+        "GetTransactionResultResponse": {
+            "type": "object",
+            "required": [
+                "success"
+            ],
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "$ref": "#/definitions/TransactionResultType"
+                        }
+                    }
+                }
+            ]
+        },
+        "GetTransactionResponse": {
+            "type": "object",
+            "required": [
+                "success"
+            ],
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "$ref": "#/definitions/TransactionType"
+                        }
+                    }
+                }
+            ]
+        },
+        "GetValidatorsResponse": {
+            "type": "object",
+            "required": [
+                "success"
+            ],
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "description": "A list of validator addresses",
+                            "type": "array",
+                            "items": {
+                                "description": "Validator address",
+                                "type": "string",
+                                "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "GetVoteResponse": {
+            "type": "object",
+            "required": [
+                "success"
+            ],
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "description": "Total votes in nanoSEM",
+                            "type": "string",
+                            "format": "int64",
+                            "pattern": "^\\d+$"
+                        }
+                    }
+                }
+            ]
+        },
+        "GetVotesResponse": {
+            "type": "object",
+            "required": [
+                "success"
+            ],
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "description": "A map of [voter address] => [votes]",
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string",
+                                "format": "int64",
+                                "pattern": "^\\d+$"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "InfoType": {
+            "type": "object",
+            "properties": {
+                "network": {
+                    "description": "The connected network",
+                    "type": "string",
+                    "enum": [
+                        "MAINNET",
+                        "TESTNET",
+                        "DEVNET"
+                    ]
+                },
+                "capabilities": {
+                    "description": "The features supported",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "clientId": {
+                    "description": "The client identifier string",
+                    "type": "string"
+                },
+                "coinbase": {
+                    "description": "The address used for establishing connections to the network",
+                    "type": "string",
+                    "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                },
+                "latestBlockNumber": {
+                    "description": "The number of the last block",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "latestBlockHash": {
+                    "description": "The hash of the last block",
+                    "type": "string",
+                    "pattern": "^(0x)?[0-9a-fA-F]{64}$"
+                },
+                "activePeers": {
+                    "description": "The number of actively connected peers",
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "pendingTransactions": {
+                    "description": "The number of transactions in pending pool",
+                    "type": "integer",
+                    "format": "int32"
+                }
+            }
+        },
+        "ListAccountsResponse": {
+            "type": "object",
+            "required": [
+                "success"
+            ],
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "description": "A list of account addresses",
+                            "type": "array",
+                            "items": {
+                                "description": "Account address",
+                                "type": "string",
+                                "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "PeerType": {
+            "type": "object",
+            "properties": {
+                "ip": {
+                    "description": "The IP address",
+                    "type": "string",
+                    "pattern": "^(\\d{1,3}\\.){3}\\d{1,3}$"
+                },
+                "port": {
+                    "description": "The port number",
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "networkVersion": {
+                    "description": "The network version",
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "clientId": {
+                    "description": "The client the peer is using",
+                    "type": "string"
+                },
+                "peerId": {
+                    "description": "The id of the peer",
+                    "type": "string"
+                },
+                "latestBlockNumber": {
+                    "description": "The latest block number of the peer",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "latency": {
+                    "description": "Latency between this node and the peer",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "capabilities": {
+                    "description": "The features supported by the peer",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "SignMessageResponse": {
+            "type": "object",
+            "required": [
+                "success"
+            ],
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "description": "The message signature encoded in hexadecimal string",
+                            "type": "string",
+                            "pattern": "^(0x)?[0-9a-fA-F]{192}$"
+                        }
+                    }
+                }
+            ]
+        },
+        "TransactionLimitsType": {
+            "type": "object",
+            "properties": {
+                "maxTransactionDataSize": {
+                    "description": "The maximum transaction size in bytes",
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "minTransactionFee": {
+                    "description": "The minimum transaction fee in nano SEM",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "minDelegateBurnAmount": {
+                    "description": "The amount of nano SEM required to burn for delegate registration",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                }
+            }
+        },
+        "TransactionType": {
+            "type": "object",
+            "properties": {
+                "hash": {
+                    "description": "The transaction hash",
+                    "type": "string",
+                    "pattern": "^(0x)?[0-9a-fA-F]{64}$"
+                },
+                "type": {
+                    "description": "The transaction type",
+                    "type": "string",
+                    "enum": [
+                        "COINBASE",
+                        "TRANSFER",
+                        "DELEGATE",
+                        "VOTE",
+                        "UNVOTE",
+                        "CREATE",
+                        "CALL"
+                    ]
+                },
+                "from": {
+                    "description": "Sender's address",
+                    "type": "string",
+                    "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                },
+                "to": {
+                    "description": "Recipient's address",
+                    "type": "string",
+                    "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                },
+                "value": {
+                    "description": "Transaction value in nano SEM",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "fee": {
+                    "description": "Transaction fee in nano SEM. For CREATE/CALL, this field is zero; use gas instead",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "nonce": {
+                    "description": "The nonce of the sender",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "timestamp": {
+                    "description": "Transaction timestamp in milliseconds specified by the sender. There can be a time drift up to 2 hours.",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "data": {
+                    "description": "Transaction data encoded in hexadecimal string",
+                    "type": "string",
+                    "pattern": "^(0x)?[0-9a-fA-F]*$"
+                },
+                "gas": {
+                    "description": "The gas limit set by the sender",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "gasPrice": {
+                    "description": "The gas Price set by the sender",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                }
+            }
+        },
+        "TransactionResultType": {
+            "type": "object",
+            "properties": {
+                "blockNumber": {
+                    "description": "The number of block that included the transaction",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "code": {
+                    "description": "The status of the transaction",
+                    "type": "string"
+                },
+                "logs": {
+                    "description": "Logs produced when executing this transaction",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/LogInfoType"
+                    }
+                },
+                "returnData": {
+                    "description": "Return data encoded in hexadecimal string",
+                    "type": "string",
+                    "pattern": "^(0x)?[0-9a-fA-F]*$"
+                },
+                "contractAddress": {
+                    "description": "Contract address if this is a CREATE transaction, or NULL",
+                    "type": "string",
+                    "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                },
+                "gas": {
+                    "description": "The gas limit set by the sender",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "gasPrice": {
+                    "description": "The gas Price set by the sender",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "gasUsed": {
+                    "description": "The gas consumed. For non-VM transactions, this field is zero",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "fee": {
+                    "description": "The transaction fee in nano SEM. For VM transactions, this field is zero",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "internalTransactions": {
+                    "description": "Internal transactions generated when executing this transaction",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/InternalTransactionType"
+                    }
+                }
+            }
+        },
+        "InternalTransactionType": {
+            "type": "object",
+            "properties": {
+                "rejected": {
+                    "description": "Whether this transaction is rejected",
+                    "type": "boolean"
+                },
+                "depth": {
+                    "description": "Call depth",
+                    "type": "string",
+                    "format": "int32",
+                    "pattern": "^\\d+$"
+                },
+                "index": {
+                    "description": "Call index",
+                    "type": "string",
+                    "format": "int32",
+                    "pattern": "^\\d+$"
+                },
+                "type": {
+                    "description" : "Call type, possibly CALL, DELEGATECALL, CALLCODE, CREATE",
+                    "type": "string"
+                },
+                "from": {
+                    "description" : "Sender address",
+                    "type": "string",
+                    "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                },
+                "to": {
+                    "description" : "Receiver address",
+                    "type": "string",
+                    "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                },
+                "nonce": {
+                    "description": "The sender's nonce",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "gas": {
+                    "description": "The gas limit",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "gasPrice": {
+                    "description": "The gas Price",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "value": {
+                    "description": "The value being passed, in nano SEM",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "data": {
+                    "description": "The data being passed, in hexadecimal string",
+                    "type": "string",
+                    "pattern": "^(0x)?[0-9a-fA-F]*$"
+                }
+            }
+        },
+        "LogInfoType": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "description": "Contract address",
+                    "type": "string",
+                    "pattern": "^(0x)?[0-9a-fA-F]{64}$"
+                },
+                "data": {
+                    "description": "Log data encoded in hexadecimal string",
+                    "type": "string",
+                    "pattern": "^(0x)?[0-9a-fA-F]*$"
+                },
+                "topics": {
+                    "description": "Log topics encoded in hexadecimal string",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "VerifyMessageResponse": {
+            "type": "object",
+            "required": [
+                "success"
+            ],
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "valid": {
+                            "description": "Whether the signature is valid",
+                            "type": "boolean"
+                        }
+                    }
+                }
+            ]
+        },
+        "ComposeRawTransactionResponse": {
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "description": "The composed raw transaction encoded in hexadecimal string",
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        },
+        "SignRawTransactionResponse": {
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "description": "The signed raw transaction encoded in hexadecimal string",
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        },
+        "GetSyncingProgressResponse": {
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "$ref": "#/definitions/SyncingProgressType"
+                        }
+                    }
+                }
+            ]
+        },
+        "SyncingProgressType": {
+            "type": "object",
+            "required": [
+                "syncing"
+            ],
+            "properties": {
+                "syncing": {
+                    "description": "Whether the node is syncing",
+                    "type": "boolean"
+                },
+                "startingHeight": {
+                    "description": "The block height at which the sync started",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "currentHeight": {
+                    "description": "The current block height",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "targetHeight": {
+                    "description": "The target block height",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                }
+            }
+        },
+        "CallResponse": {
+            "type": "object",
+            "required": [
+                "success"
+            ],
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "description": "The return data in hex",
+                            "type": "string",
+                            "pattern": "^(0x)?[0-9a-fA-F]*$"
+                        }
+                    }
+                }
+            ]
+        },
+        "EstimateGasResponse": {
+            "type": "object",
+            "required": [
+                "success"
+            ],
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "properties": {
+                        "result": {
+                            "description": "The estimated gas usage",
+                            "type": "string",
+                            "format": "int64",
+                            "pattern": "^\\d+$"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "info": {
+        "description": "Semux is an experimental high-performance blockchain platform that powers decentralized application.",
+        "version": "2.4.0",
+        "title": "Semux API",
+        "contact": {
+            "name": "Semux Foundation",
+            "url": "https://www.semux.org"
+        },
+        "license": {
+            "name": "MIT License",
+            "url": "https://opensource.org/licenses/mit-license.php"
+        }
+    },
+    "paths": {
+        "/node": {
+            "post": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Add node",
+                "description": "Adds a node to node manager.",
+                "operationId": "addNode",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "node",
+                        "in": "query",
+                        "description": "Address of the node in host:port format",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/AddNodeResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/blacklist": {
+            "post": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Add to blacklist",
+                "description": "Adds an IP address to blacklist.",
+                "operationId": "addToBlacklist",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "ip",
+                        "in": "query",
+                        "description": "IP address",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(\\d{1,3}\\.){3}\\d{1,3}$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/whitelist": {
+            "post": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Add to whitelist",
+                "description": "Adds an IP address to whitelist.",
+                "operationId": "addToWhitelist",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "ip",
+                        "in": "query",
+                        "description": "IP address",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(\\d{1,3}\\.){3}\\d{1,3}$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/account": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Get account",
+                "description": "Returns an account.",
+                "operationId": "getAccount",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "address",
+                        "in": "query",
+                        "description": "Address of account",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/GetAccountResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Create or import an account",
+                "description": "Creates a new account by generating a new private key or importing an existing private key when parameter 'privateKey' is provided.",
+                "operationId": "createAccount",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "name",
+                        "in": "query",
+                        "description": "Assigned alias to the created account.",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "privateKey",
+                        "in": "query",
+                        "description": "The private key to be imported, create a new key if omitted",
+                        "required": false,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{96}$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/CreateAccountResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Delete account",
+                "description": "Deletes an account from this wallet.",
+                "operationId": "deleteAccount",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "address",
+                        "in": "query",
+                        "description": "Address of the account",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/DeleteAccountResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/delegate": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Get a delegate",
+                "description": "Returns a delegate.",
+                "operationId": "getDelegate",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "address",
+                        "in": "query",
+                        "description": "Delegate address",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/GetDelegateResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/account/transactions": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Get account transactions",
+                "description": "Returns transactions from/to an account.",
+                "operationId": "getAccountTransactions",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "address",
+                        "in": "query",
+                        "description": "Address of account",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    },
+                    {
+                        "name": "from",
+                        "in": "query",
+                        "description": "Starting range of transactions",
+                        "required": true,
+                        "type": "string",
+                        "format": "int32",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "to",
+                        "in": "query",
+                        "description": "Ending range of transactions",
+                        "required": true,
+                        "type": "string",
+                        "format": "int32",
+                        "pattern": "^\\d+$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/GetAccountTransactionsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/account/pending-transactions": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Get pending transactions of the account",
+                "description": "Returns pending transactions from/to an account.",
+                "operationId": "getAccountPendingTransactions",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "address",
+                        "in": "query",
+                        "description": "Address of account",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    },
+                    {
+                        "name": "from",
+                        "in": "query",
+                        "description": "Starting range of transactions",
+                        "required": true,
+                        "type": "string",
+                        "format": "int32",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "to",
+                        "in": "query",
+                        "description": "Ending range of transactions",
+                        "required": true,
+                        "type": "string",
+                        "format": "int32",
+                        "pattern": "^\\d+$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/GetAccountPendingTransactionsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/account/votes": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Get account votes",
+                "description": "Returns votes from the account.",
+                "operationId": "getAccountVotes",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "address",
+                        "in": "query",
+                        "description": "Address of account",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/GetAccountVotesResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/block-by-hash": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Get block by hash",
+                "description": "Returns a block by block hash.",
+                "operationId": "getBlockByHash",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "hash",
+                        "in": "query",
+                        "description": "Hash of block",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{64}$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/GetBlockResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/block-by-number": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Get block by number",
+                "description": "Returns a block by block number.",
+                "operationId": "getBlockByNumber",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "number",
+                        "in": "query",
+                        "description": "Number of block",
+                        "required": true,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/GetBlockResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/delegates": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Get all delegates",
+                "description": "Returns a list of delegates.",
+                "operationId": "getDelegates",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/GetDelegatesResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/info": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Get info",
+                "description": "Returns kernel info.",
+                "operationId": "getInfo",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/GetInfoResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/latest-block": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Get latest block",
+                "description": "Returns the latest block.",
+                "operationId": "getLatestBlock",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/GetLatestBlockResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/latest-block-number": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Get latest block number",
+                "description": "Returns the number of the latest block.",
+                "operationId": "getLatestBlockNumber",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/GetLatestBlockNumberResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/peers": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Get peers",
+                "description": "Returns connected peers.",
+                "operationId": "getPeers",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/GetPeersResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/pending-transactions": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Get pending transactions",
+                "description": "Returns all the pending transactions.",
+                "operationId": "getPendingTransactions",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/GetPendingTransactionsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/transaction": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Get transaction",
+                "description": "Returns a transactions if exists.",
+                "operationId": "getTransaction",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "hash",
+                        "in": "query",
+                        "description": "Transaction hash",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{64}$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/GetTransactionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/transaction-result": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Get transaction result",
+                "description": "Returns the result of the requested transaction.",
+                "operationId": "getTransactionResult",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "hash",
+                        "in": "query",
+                        "description": "Transaction hash",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{64}$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/GetTransactionResultResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/transaction-limits": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Get transaction limits",
+                "description": "Returns transaction limitations including minimum transaction fee and maximum transaction size.",
+                "operationId": "getTransactionLimits",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "description": "Type of transaction",
+                        "required": true,
+                        "type": "string",
+                        "enum": [
+                            "COINBASE",
+                            "TRANSFER",
+                            "DELEGATE",
+                            "VOTE",
+                            "UNVOTE",
+                            "CREATE",
+                            "CALL"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/GetTransactionLimitsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/validators": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Get validators",
+                "description": "Returns a list of validators in Semux addresses.",
+                "operationId": "getValidators",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/GetValidatorsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/vote": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Get vote",
+                "description": "Returns the vote from a voter to a delegate.",
+                "operationId": "getVote",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "delegate",
+                        "in": "query",
+                        "description": "Delegate address",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    },
+                    {
+                        "name": "voter",
+                        "in": "query",
+                        "description": "Voter address",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/GetVoteResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/votes": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Get a delegate's votes",
+                "description": "Returns all the votes to a delegate as a map of [voter address] => [votes]",
+                "operationId": "getVotes",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "delegate",
+                        "in": "query",
+                        "description": "Delegate address",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/GetVotesResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/accounts": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "List accounts",
+                "description": "Returns accounts in the wallet.",
+                "operationId": "listAccounts",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/ListAccountsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/sign-message": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Sign a message",
+                "description": "Sign a message.",
+                "operationId": "signMessage",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "address",
+                        "in": "query",
+                        "description": "Signing address. The address must exist in the wallet.data of this Semux node.",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    },
+                    {
+                        "name": "message",
+                        "in": "query",
+                        "description": "Message to sign in UTF-8 string",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/SignMessageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/verify-message": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Verify a message",
+                "description": "Verify a signed message.",
+                "operationId": "verifyMessage",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "address",
+                        "in": "query",
+                        "description": "Address of the message signer",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    },
+                    {
+                        "name": "message",
+                        "in": "query",
+                        "description": "Message in UTF-8 string",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "signature",
+                        "in": "query",
+                        "description": "Signature to verify",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{192}$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/VerifyMessageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/transaction/transfer": {
+            "post": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Transfer coins",
+                "description": "Transfers coins to another address.",
+                "operationId": "transfer",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "from",
+                        "in": "query",
+                        "description": "Sender's address. The account must exist in the wallet of this node.",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    },
+                    {
+                        "name": "to",
+                        "in": "query",
+                        "description": "Recipient's address",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    },
+                    {
+                        "name": "value",
+                        "in": "query",
+                        "description": "Amount of value to transfer in nano SEM",
+                        "required": true,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "fee",
+                        "in": "query",
+                        "description": "Transaction fee in nano SEM, default to minimum fee if omitted",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "nonce",
+                        "in": "query",
+                        "description": "Transaction nonce, default to sender's nonce if omitted",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "data",
+                        "in": "query",
+                        "description": "Transaction data encoded in hexadecimal string",
+                        "required": false,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]+$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/DoTransactionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/transaction/create": {
+            "post": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Create a contract",
+                "description": "Create a VM contract.",
+                "operationId": "create",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "from",
+                        "in": "query",
+                        "description": "Sender's address. The address must exist in the wallet.data of this Semux node.",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    },
+                    {
+                        "name": "value",
+                        "in": "query",
+                        "description": "Amount of SEM to transfer in nano SEM",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "nonce",
+                        "in": "query",
+                        "description": "Transaction nonce, default to sender's nonce if omitted",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "data",
+                        "in": "query",
+                        "description": "The contract data encoded in hexadecimal string",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]+$"
+                    },
+                    {
+                        "name": "gas",
+                        "in": "query",
+                        "description": "The gas limit for the call",
+                        "required": true,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "gasPrice",
+                        "in": "query",
+                        "description": "The gas price",
+                        "required": true,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/DoTransactionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/transaction/call": {
+            "post": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Call a contract.",
+                "description": "Call a VM contract.",
+                "operationId": "call",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "from",
+                        "in": "query",
+                        "description": "Sender's address. The address must exist in the wallet.data of this Semux node.",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    },
+                    {
+                        "name": "to",
+                        "in": "query",
+                        "description": "Recipient's address (the contract address)",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    },
+                    {
+                        "name": "value",
+                        "in": "query",
+                        "description": "Amount of value to transfer in nano SEM",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "nonce",
+                        "in": "query",
+                        "description": "Transaction nonce, default to sender's nonce if omitted",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "data",
+                        "in": "query",
+                        "description": "Transaction data encoded in hexadecimal string",
+                        "required": false,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]+$"
+                    },
+                    {
+                        "name": "gas",
+                        "in": "query",
+                        "description": "The gas limit for the call",
+                        "required": true,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "gasPrice",
+                        "in": "query",
+                        "description": "The gas price in nano SEM",
+                        "required": true,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/DoTransactionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/transaction/unvote": {
+            "post": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Unvote",
+                "description": "Unvotes for a delegate.",
+                "operationId": "unvote",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "from",
+                        "in": "query",
+                        "description": "Voter's address. The address must exist in the wallet.data of this Semux node.",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    },
+                    {
+                        "name": "to",
+                        "in": "query",
+                        "description": "Delegate address",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    },
+                    {
+                        "name": "value",
+                        "in": "query",
+                        "description": "Number of votes in nano SEM",
+                        "required": true,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "fee",
+                        "in": "query",
+                        "description": "Transaction fee in nano SEM, default to minimum fee if omitted",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "nonce",
+                        "in": "query",
+                        "description": "Transaction nonce, default to sender's nonce if omitted",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/DoTransactionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/transaction/vote": {
+            "post": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Vote",
+                "description": "Votes for a delegate.",
+                "operationId": "vote",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "from",
+                        "in": "query",
+                        "description": "Voter's address. The address must exist in the wallet.data of this Semux node.",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    },
+                    {
+                        "name": "to",
+                        "in": "query",
+                        "description": "Delegate address",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    },
+                    {
+                        "name": "value",
+                        "in": "query",
+                        "description": "Number of votes in nano SEM",
+                        "required": true,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "fee",
+                        "in": "query",
+                        "description": "Transaction fee in nano SEM, default to minimum fee if omitted",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "nonce",
+                        "in": "query",
+                        "description": "Transaction nonce, default to sender's nonce if omitted",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/DoTransactionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/transaction/delegate": {
+            "post": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Register delegate",
+                "description": "Registers as a delegate",
+                "operationId": "registerDelegate",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "from",
+                        "in": "query",
+                        "description": "Registering address",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    },
+                    {
+                        "name": "fee",
+                        "in": "query",
+                        "description": "Transaction fee in nano SEM, default to minimum fee if omitted",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "nonce",
+                        "in": "query",
+                        "description": "Transaction nonce, default to sender's nonce if omitted",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "data",
+                        "in": "query",
+                        "description": "Delegate name in hexadecimal encoded UTF-8 string, 16 bytes of data at maximum",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]+$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/DoTransactionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/transaction/raw": {
+            "post": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Broadcast a raw transaction",
+                "description": "Broadcasts a raw transaction to the network.",
+                "operationId": "broadcastRawTransaction",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "raw",
+                        "in": "query",
+                        "description": "Raw transaction encoded in hexadecimal string.",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]+$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/DoTransactionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/call": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Make a local call",
+                "description": "Executes a new message call immediately without creating a transaction on the block chain.",
+                "operationId": "localCall",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "from",
+                        "in": "query",
+                        "description": "Sender's address. The address must exist in the wallet.data of this Semux node.",
+                        "required": false,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    },
+                    {
+                        "name": "to",
+                        "in": "query",
+                        "description": "Recipient's address (the contract address)",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    },
+                    {
+                        "name": "value",
+                        "in": "query",
+                        "description": "Amount of value to transfer in nano SEM",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "nonce",
+                        "in": "query",
+                        "description": "Transaction nonce, default to sender's nonce if omitted",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "data",
+                        "in": "query",
+                        "description": "Transaction data encoded in hexadecimal string",
+                        "required": false,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]+$"
+                    },
+                    {
+                        "name": "gas",
+                        "in": "query",
+                        "description": "The gas limit for the call",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "gasPrice",
+                        "in": "query",
+                        "description": "The gas price in nanoSEM",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/CallResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/estimate-gas": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Estimate gas",
+                "description": "Estimate the gas usage of a transaction.",
+                "operationId": "estimateGas",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "from",
+                        "in": "query",
+                        "description": "Sender's address. The address must exist in the wallet.data of this Semux node.",
+                        "required": false,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    },
+                    {
+                        "name": "to",
+                        "in": "query",
+                        "description": "Recipient's address (the contract address)",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    },
+                    {
+                        "name": "value",
+                        "in": "query",
+                        "description": "Amount of value to transfer in nano SEM",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "nonce",
+                        "in": "query",
+                        "description": "Transaction nonce, default to sender's nonce if omitted",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "data",
+                        "in": "query",
+                        "description": "Transaction data encoded in hexadecimal string",
+                        "required": false,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]+$"
+                    },
+                    {
+                        "name": "gas",
+                        "in": "query",
+                        "description": "The gas limit for the call",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "gasPrice",
+                        "in": "query",
+                        "description": "The gas price in SEM",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/EstimateGasResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/compose-raw-transaction": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Compose an unsigned raw transaction",
+                "description": "Compose an unsigned raw transaction then return its hexadecimal encoded string. An unsigned raw transaction can be signed using /sign-raw-transaction API.",
+                "operationId": "composeRawTransaction",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "network",
+                        "in": "query",
+                        "description": "Network name",
+                        "required": true,
+                        "type": "string",
+                        "enum": [
+                            "MAINNET",
+                            "TESTNET",
+                            "DEVNET"
+                        ]
+                    },
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "description": "Transaction type",
+                        "required": true,
+                        "type": "string",
+                        "enum": [
+                            "TRANSFER",
+                            "DELEGATE",
+                            "VOTE",
+                            "UNVOTE",
+                            "CREATE",
+                            "CALL"
+                        ]
+                    },
+                    {
+                        "name": "to",
+                        "in": "query",
+                        "description": "Recipient's address",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    },
+                    {
+                        "name": "value",
+                        "in": "query",
+                        "description": "Amount of value to transfer in nano SEM",
+                        "required": true,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "fee",
+                        "in": "query",
+                        "description": "Transaction fee in nano SEM, default to minimum fee if omitted",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "nonce",
+                        "in": "query",
+                        "description": "Transaction nonce, default to sender's nonce if omitted",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "timestamp",
+                        "in": "query",
+                        "description": "Transaction timestamp in milliseconds. Default to current time.",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                        "name": "data",
+                        "in": "query",
+                        "description": "Hexadecimal encoded transaction data.",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^(0x)?[0-9a-fA-F]+$"
+                    },
+                    {
+                        "name": "gas",
+                        "in": "query",
+                        "description": "The gas limit for the call",
+                        "required": false,
+                        "type": "string",
+                        "format": "int64",
+                        "pattern": "^\\d+$"
+                    },
+                    {
+                      "name": "gasPrice",
+                      "in": "query",
+                      "description": "The gas price",
+                      "required": false,
+                      "type": "string",
+                      "format": "int64",
+                      "pattern": "^\\d+$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/ComposeRawTransactionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/sign-raw-transaction": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Sign an unsigned raw transaction",
+                "description": "Sign an unsigned raw transaction then return its hexadecimal encoded string. An unsigned raw transaction can be created using /compose-raw-transaction API.",
+                "operationId": "signRawTransaction",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "raw",
+                        "in": "query",
+                        "description": "Unsigned raw transaction encoded in hexadecimal string.",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]+$"
+                    },
+                    {
+                        "name": "address",
+                        "in": "query",
+                        "description": "Signer's address. This address must exist in the wallet.",
+                        "required": true,
+                        "type": "string",
+                        "pattern": "^(0x)?[0-9a-fA-F]{40}$"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/SignRawTransactionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        },
+        "/syncing": {
+            "get": {
+                "tags": [
+                    "semux"
+                ],
+                "summary": "Get syncing progress",
+                "description": "Returns an object with data about the sync status",
+                "operationId": "getSyncingProgress",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "An object about the current sync status",
+                        "schema": {
+                            "$ref": "#/definitions/GetSyncingProgressResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiHandlerResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        }
+    },
+    "produces": [
+        "application/json"
+    ],
+    "schemes": [
+        "http"
+    ],
+    "security": [
+        {
+            "basicAuth": []
+        }
+    ],
+    "securityDefinitions": {
+        "basicAuth": {
+            "type": "basic"
+        }
+    },
+    "swagger": "2.0"
+}

--- a/src/test/java/org/semux/core/TransactionResultTest.java
+++ b/src/test/java/org/semux/core/TransactionResultTest.java
@@ -109,7 +109,9 @@ public class TransactionResultTest {
         long blockNumber = 4;
         List<SemuxInternalTransaction> internalTransactions = new ArrayList<>();
         internalTransactions
-                .add(new SemuxInternalTransaction(false, 1, 2, OpCode.CALL, Bytes.random(20), Bytes.random(20),
+                .add(new SemuxInternalTransaction(Bytes.random(32),
+                        false, 1, 2, OpCode.CALL,
+                        Bytes.random(20), Bytes.random(20),
                         3, Amount.of(1), Bytes.random(5), 4, Amount.of(10)));
 
         TransactionResult tr1 = new TransactionResult(code, returnData, logs);


### PR DESCRIPTION
## Description

Add internal transaction index to support account-based look-up.

API changes:
- A new property, `internalTransactionCount`, is added to `AccountType`;
- A new endpoint `/account/internal-transactions` is added.

## Test Plan

Existing tests and new tests

## Related issues and/or PRs

#249