### PR TITLE
Add more Mainnet DNS seed nodes

### DIFF
--- a/config/semux.properties
+++ b/config/semux.properties
@@ -45,7 +45,7 @@ net.relayRedundancy = 8
 net.channelIdleTimeout = 120000
 
 # DNS Seed (comma delimited)
-net.dnsSeeds.mainNet = mainnet.semux.org
+net.dnsSeeds.mainNet = mainnet.semux.org, mainnet-seed.semux.info
 net.dnsSeeds.testNet = testnet.semux.org, testnet-seed.semux.info
 
 #================


### PR DESCRIPTION
Looks like semux01 and semux02 are temporarily down, so wallets are not syncing. I'm adding another seed node with few validators @ semux.info 